### PR TITLE
Changes to compile in Windows (tested in MSVC 2013)

### DIFF
--- a/ffi.c
+++ b/ffi.c
@@ -2982,6 +2982,19 @@ static int cmodule_newindex(lua_State* L)
     return 0;
 }
 
+static int cmodule_gc(lua_State* L)
+{
+    void * lib = *(void **)lua_touserdata(L, 1);
+   
+#ifdef _WIN32
+    FreeLibrary((HANDLE)lib);
+#else
+    dlclose(lib);
+#endif
+    
+    return 0;
+}
+
 static int jit_gc(lua_State* L)
 {
     size_t i;
@@ -3100,6 +3113,7 @@ static const luaL_Reg ctype_mt[] = {
 static const luaL_Reg cmodule_mt[] = {
     {"__index", &cmodule_index},
     {"__newindex", &cmodule_newindex},
+    {"__gc", &cmodule_gc},
     {NULL, NULL}
 };
 

--- a/ffi.h
+++ b/ffi.h
@@ -40,10 +40,10 @@ extern "C" {
 #include <unistd.h>
 #include <dlfcn.h>
 #include <sys/mman.h>
-#endif
-
 #include <complex.h>
 #define HAVE_COMPLEX
+#endif
+
 #define HAVE_LONG_DOUBLE
 
 #ifndef NDEBUG

--- a/test.c
+++ b/test.c
@@ -17,10 +17,9 @@
 #include <windows.h>
 #else
 #include <errno.h>
-#endif
-
 #include <complex.h>
 #define HAVE_COMPLEX
+#endif
 
 #ifdef __cplusplus
 # define EXTERN_C extern "C"
@@ -29,7 +28,7 @@
 #endif
 
 #ifdef _WIN32
-#define EXPORT EXTERN_C __declspec(dllexport)
+#define EXPORT /*EXTERN_C*/ __declspec(dllexport) // <- doesn't seem quite right, but I think extern was giving me issues
 #elif defined __GNUC__
 #define EXPORT EXTERN_C __attribute__((visibility("default")))
 #else


### PR DESCRIPTION
Hi. This seems to run and pass the tests, after a little work on those as well.

The first commit pertains to my own particular use case, where **luaffifb** is being loaded as a [Corona SDK](https://coronalabs.com) plugin. Without adding the `__gc` method to modules, the FFI-loaded DLLs were still active if you did a reset in their simulator. This created some baffling failures on the second run of the tests. :smile: Maybe not generally useful, but I include it for completeness.

Everything else seemed to come down to `<complex.h>` being included and then a lot of warnings-as-errors from lack of casts.

Same thing with complex in `test.c`.

In that same file, I got some odd behavior with `extern`, which I just commented out when defining `EXPORT`. That can probably be done better.

The FFI namespacing toward the very end of `test.lua` was giving me trouble, until I used `__cdecl` instead of `C`. I haven't quite puzzled out why this worked well on Mac. :confused:

My `msvcbuild.bat` is a bit customized, so I'm not sure it's commit-worthy. Instead, just some comments about it here.

It's fairly intact, but loads the (MSVC 2013) command line stuff so I can just click the batch file:

`
if not defined DevEnvDir (
    call "%VS120COMNTOOLS%vsvars32.bat"
)
`
 I removed the `/I"msvc"` includes for C99 headers in favor of Visual Studio's own, which seems to work well. Otherwise, the only interesting thing was that there was a (spurious?) `/debug` in **release**'s **DO_LINK** line, that I also removed.

I think that about covers it. Let me know about any concerns.
