### PR TITLE
Fixing memleak: jit->pages not free'd

### DIFF
--- a/ffi.c
+++ b/ffi.c
@@ -2990,6 +2990,7 @@ static int jit_gc(lua_State* L)
     for (i = 0; i < jit->pagenum; i++) {
         FreePage(jit->pages[i], jit->pages[i]->size);
     }
+    free(jit->pages);
     free(jit->globals);
     return 0;
 }


### PR DESCRIPTION
Without this fix (run in directory with ffi.so):
    valgrind --trace-children=yes --leak-check=full --show-leak-kinds=all lua -e "package.cpath='./?.so';require('ffi')"
    ...
    ==29982== 8 bytes in 1 blocks are definitely lost in loss record 1 of 5
    ==29982==    at 0x4C28C20: malloc (vg_replace_malloc.c:296)
    ==29982==    by 0x4C2AFCF: realloc (vg_replace_malloc.c:692)
    ==29982==    by 0x5AEDA37: reserve_code (call.c:134)
    ==29982==    by 0x5AED7C6: compile (call.c:75)
    ==29982==    by 0x5AEB5F4: compile_globals (call_x64.h:269)
    ==29982==    by 0x5AFA4F9: setup_upvals (ffi.c:3362)
    ==29982==    by 0x4078F3: luaD_precall (in /home/.../test-ffi-leak)
    ==29982==    by 0x407CC2: luaD_call (in /home/.../test-ffi-leak)
    ==29982==    by 0x407D20: luaD_callnoyield (in /home/.../test-ffi-leak)
    ==29982==    by 0x40553B: lua_callk (in /home/.../test-ffi-leak)
    ==29982==    by 0x5AFB3AB: luaopen_ffi (ffi.c:3693)
    ==29982==    by 0x4078F3: luaD_precall (in /home/.../test-ffi-leak)
