### PR TITLE
Fix invalid >2GB relative jumps to shared global functions.

### DIFF
--- a/call_x64.h
+++ b/call_x64.h
@@ -18,143 +18,124 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-static const unsigned char build_actionlist[2100] = {
-  248,10,184,1,0.0,0.0,0.0,76,139,109,252,240,76,139,101,252,248,72,137,252,
-  236,93,195,255,248,11,232,251,1,0,72,185,237,237,137,1,184,0,0.0,0.0,0.0,
-  76,139,109,252,240,76,139,101,252,248,72,137,252,236,93,195,255,248,12,102.0,
-  15.0,214,68,36,32,232,251,1,0,72,185,237,237,137,1,252,243.0,15.0,126,68,
-  36,32,76,137,231,232,251,1,1,252,233,244,10,255,248,13,15.0,182,192,137,68,
-  36,32,232,251,1,0,72,185,237,237,137,1,139,68,36,32,72,137,198,76,137,231,
-  232,251,1,2,252,233,244,10,255,248,14,137,68,36,32,232,251,1,0,72,185,237,
-  237,137,1,139,68,36,32,72,137,198,76,137,231,232,251,1,3,252,233,244,10,255,
-  248,15,137,68,36,32,232,251,1,0,72,185,237,237,137,1,139,68,36,32,72,137,
-  198,76,137,231,232,251,1,4,252,233,244,10,255,248,16,72,137,68,36,32,232,
-  251,1,0,72,185,237,237,137,1,72,139,68,36,32,72,137,198,76,137,231,232,251,
-  1,5,252,233,244,10,255,248,17,72,137,68,36,32,232,251,1,0,72,185,237,237,
-  137,1,72,139,68,36,32,72,137,198,76,137,231,232,251,1,5,252,233,244,10,255,
-  248,18,102,184,0,0.0,72,190,237,237,76,137,231,232,251,1,6,255,248,19,102,
-  184,0,0.0,72,190,237,237,76,137,231,232,251,1,6,255,248,20,102.0,15.0,214,
-  69,252,240,102.0,15.0,214,77,232,102.0,15.0,214,85,224,102.0,15.0,214,93,
-  216,102.0,15.0,214,101,208,102.0,15.0,214,109,200,102.0,15.0,214,117,192,
-  102.0,15.0,214,125,184,72,137,125,176,72,137,117,168,72,137,85,160,72,137,
-  77,152,76,137,69,144,76,137,77,136,195,255,72,139,141,233,255,72,137,132,
-  253,36,233,255,221.0,133,233,255,217.0,133,233,255,252,243.0,15.0,126,133,
-  233,255,252,243.0,15.0,90,133,233,255,221.0,156,253,36,233,255,217.0,156,
-  253,36,233,255,102.0,15.0,214,132,253,36,233,255,252,242.0,15.0,90,192,102.0,
-  15.0,214,132,253,36,233,255,252,242.0,15.0,90,192,102.0,15.0,126,132,253,
-  36,233,255,85,72,137,229,65,84,72,129.0,252,236,239,232,244,20,255,73,188,
-  237,237,255,72,199.0,194,237,72,199.0,198,237,76,137,231,232,251,1,7,255,
-  72,199.0,194,237,72,199.0,198,252,255,252,255.0,252,255.0,252,255.0,76,137,
-  231,232,251,1,7,255,72,199.0,194,237,72,199.0,198,237,76,137,231,232,251,
-  1,7,72,186,237,237,72,199.0,198,252,255,252,255.0,252,255.0,252,255.0,76,
-  137,231,232,251,1,8,255,72,137,8,72,199.0,198,252,254,252,255.0,252,255.0,
-  252,255.0,76,137,231,232,251,1,9,255,72,186,237,237,72,199.0,198,0,0.0,0.0,
-  0.0,76,137,231,232,251,1,8,255,72,137,8,255,102.0,15.0,214,0,255,217.0,24,
-  255,217.0,88,4,255,102.0,15.0,214,64,8,255,76,137,231,232,251,1,1,255,15.0,
-  182,201,72,137,206,76,137,231,232,251,1,2,255,15.0,182,201,255,15.0,190,201,
-  255,72,137,206,76,137,231,232,251,1,3,255,15.0,183,201,255,15.0,191,201,255,
-  72,137,206,76,137,231,232,251,1,4,255,72,185,237,237,72,199.0,194,237,72,
-  199.0,198,237,76,137,231,232,251,1,10,255,72,199.0,194,237,72,199.0,198,252,
-  254,252,255.0,252,255.0,252,255.0,76,137,231,232,251,1,7,72,185,237,237,72,
-  199.0,194,252,255,252,255.0,252,255.0,252,255.0,72,199.0,198,252,254,252,
-  255.0,252,255.0,252,255.0,76,137,231,232,251,1,11,72,137,68,36,32,72,199.0,
-  198,252,252,252,255.0,252,255.0,252,255.0,76,137,231,232,251,1,12,72,139,
-  68,36,32,255,72,199.0,194,237,72,199.0,198,252,254,252,255.0,252,255.0,252,
-  255.0,76,137,231,232,251,1,7,72,185,237,237,72,199.0,194,252,255,252,255.0,
-  252,255.0,252,255.0,72,199.0,198,252,254,252,255.0,252,255.0,252,255.0,76,
-  137,231,232,251,1,13,137,68,36,32,72,199.0,198,252,252,252,255.0,252,255.0,
-  252,255.0,76,137,231,232,251,1,12,139,68,36,32,255,72,199.0,198,252,254,252,
-  255.0,252,255.0,252,255.0,76,137,231,232,251,1,12,255,72,199.0,198,252,255,
-  252,255.0,252,255.0,252,255.0,76,137,231,232,251,1,14,255,72,199.0,198,252,
-  255,252,255.0,252,255.0,252,255.0,76,137,231,232,251,1,15,255,137,68,36,32,
-  72,199.0,198,252,253,252,255.0,252,255.0,252,255.0,76,137,231,232,251,1,12,
-  139,68,36,32,255,72,199.0,198,252,255,252,255.0,252,255.0,252,255.0,76,137,
-  231,232,251,1,16,255,72,199.0,198,252,255,252,255.0,252,255.0,252,255.0,76,
-  137,231,232,251,1,17,255,72,137,68,36,32,72,199.0,198,252,253,252,255.0,252,
-  255.0,252,255.0,76,137,231,232,251,1,12,72,139,68,36,32,255,72,199.0,198,
-  252,255,252,255.0,252,255.0,252,255.0,76,137,231,232,251,1,18,72,137,68,36,
-  32,72,199.0,198,252,253,252,255.0,252,255.0,252,255.0,76,137,231,232,251,
-  1,12,72,139,68,36,32,255,72,199.0,198,252,255,252,255.0,252,255.0,252,255.0,
-  76,137,231,232,251,1,19,102.0,15.0,214,68,36,32,72,199.0,198,252,253,252,
-  255.0,252,255.0,252,255.0,76,137,231,232,251,1,12,255,252,242.0,15.0,90,68,
-  36,32,255,252,243.0,15.0,126,68,36,32,255,72,199.0,198,252,255,252,255.0,
-  252,255.0,252,255.0,76,137,231,232,251,1,20,102.0,15.0,214,68,36,32,72,199.0,
-  198,252,253,252,255.0,252,255.0,252,255.0,76,137,231,232,251,1,12,252,243.0,
-  15.0,126,68,36,32,255,72,199.0,198,252,255,252,255.0,252,255.0,252,255.0,
-  76,137,231,232,251,1,21,102.0,15.0,214,68,36,32,102.0,15.0,214,76,36,40,72,
-  199.0,198,252,253,252,255.0,252,255.0,252,255.0,76,137,231,232,251,1,12,252,
-  243.0,15.0,126,68,36,32,252,243.0,15.0,126,76,36,40,255,72,139,141,233,72,
-  199.0,194,252,255,252,255.0,252,255.0,252,255.0,76,137,230,72,137,207,232,
-  251,1,21,72,131.0,252,236,4,72,199.0,198,252,253,252,255.0,252,255.0,252,
-  255.0,76,137,231,232,251,1,12,255,76,139,101,252,248,72,137,252,236,93,194,
-  236,255,85,72,137,229,65,84,65,85,73,137,252,252,76,137,231,232,251,1,22,
-  73,137,197,72,129.0,252,248,239,15.0,140,244,18,255,15.0,143,244,19,255,72,
-  193.0,224,4,72,41,196,72,129.0,252,236,239,255,72,186,237,237,72,199.0,198,
-  0,0.0,0.0,0.0,76,137,231,232,251,1,8,72,131.0,252,236,16,255,72,185,237,237,
-  72,199.0,194,237,72,199.0,198,237,76,137,231,232,251,1,11,255,72,185,237,
-  237,72,199.0,194,237,72,199.0,198,237,76,137,231,232,251,1,23,255,72,185,
-  237,237,72,199.0,194,237,72,199.0,198,237,76,137,231,232,251,1,13,255,72,
-  199.0,198,237,76,137,231,232,251,1,15,255,15.0,182,192,255,15.0,190,192,255,
-  15.0,183,192,255,15.0,191,192,255,72,199.0,198,237,76,137,231,232,251,1,15,
-  131.0,252,248,0,15.0,149.0,208,15.0,182,192,255,72,199.0,198,237,76,137,231,
-  232,251,1,14,255,72,199.0,198,237,76,137,231,232,251,1,18,255,72,199.0,198,
-  237,76,137,231,232,251,1,16,255,72,199.0,198,237,76,137,231,232,251,1,17,
-  255,72,199.0,198,237,76,137,231,232,251,1,19,255,72,199.0,198,237,76,137,
-  231,232,251,1,21,255,252,243.0,15.0,126,193,255,72,141,132,253,36,233,72,
-  131.0,252,236,4,72,199.0,194,237,76,137,230,72,137,199,232,251,1,21,255,72,
-  199.0,198,237,76,137,231,232,251,1,20,255,72,199.0,198,237,76,137,231,232,
-  251,1,20,137,4,36,217.0,4,36,255,137,20,36,217.0,4,36,255,72,137,224,72,129.0,
-  192,239,73,137,192,72,199.0,193,237,76,137,252,234,72,199.0,198,237,76,137,
-  231,232,251,1,24,255,72,137,224,72,129.0,192,239,73,137,192,72,199.0,193,
-  237,76,137,252,234,72,199.0,198,237,76,137,231,232,251,1,25,255,72,137,224,
-  72,129.0,192,239,73,137,193,73,199.0,192,237,72,199.0,193,237,76,137,252,
-  234,72,199.0,198,237,76,137,231,232,251,1,26,255,72,185,237,237,139,1,72,
-  137,199,232,251,1,27,255,72,131.0,196,32,255,252,243.0,15.0,126,188,253,36,
-  233,255,252,243.0,15.0,126,180,253,36,233,255,252,243.0,15.0,126,172,253,
-  36,233,255,252,243.0,15.0,126,164,253,36,233,255,252,243.0,15.0,126,156,253,
-  36,233,255,252,243.0,15.0,126,148,253,36,233,255,252,243.0,15.0,126,140,253,
-  36,233,255,252,243.0,15.0,126,132,253,36,233,255,76,139,140,253,36,233,255,
-  76,139,132,253,36,233,255,72,139,140,253,36,233,255,72,139,148,253,36,233,
-  255,72,139,180,253,36,233,255,72,139,60,36,255,72,129.0,196,239,255,176,8,
-  255,232,251,1,28,72,131.0,252,236,48,255,72,137,68,36,32,232,251,1,0,72,185,
-  237,237,137,1,72,186,237,237,72,199.0,198,237,76,137,231,232,251,1,8,72,139,
-  76,36,32,72,137,8,252,233,244,10,255,252,233,244,17,255,252,233,244,16,255,
-  72,137,68,36,32,232,251,1,0,72,185,237,237,137,1,72,186,237,237,72,199.0,
-  198,0,0.0,0.0,0.0,76,137,231,232,251,1,8,72,139,76,36,32,72,137,8,252,233,
-  244,10,255,102.0,15.0,214,68,36,32,232,251,1,0,72,185,237,237,137,1,72,186,
-  237,237,72,199.0,198,237,76,137,231,232,251,1,8,72,139,76,36,32,72,137,8,
-  252,233,244,10,255,102.0,15.0,214,76,36,40,102.0,15.0,214,68,36,32,232,251,
-  1,0,72,185,237,237,137,1,72,186,237,237,72,199.0,198,237,76,137,231,232,251,
-  1,8,72,139,76,36,40,72,137,72,8,72,139,76,36,32,72,137,8,252,233,244,10,255,
-  252,233,244,11,255,252,233,244,13,255,252,233,244,14,255,252,233,244,15,255,
-  252,243.0,15.0,90,192,252,233,244,12,255
+static const unsigned char build_actionlist[2157] = {
+  72,139,141,233,255,72,137,132,253,36,233,255,221,133,233,255,217,133,233,
+  255,252,243,15,126,133,233,255,252,243,15,90,133,233,255,221,156,253,36,233,
+  255,217,156,253,36,233,255,102,15,214,132,253,36,233,255,252,242,15,90,192,
+  102,15,214,132,253,36,233,255,252,242,15,90,192,102,15,126,132,253,36,233,
+  255,85,72,137,229,65,84,72,129,252,236,239,102,15,214,69,252,240,102,15,214,
+  77,232,102,15,214,85,224,102,15,214,93,216,102,15,214,101,208,102,15,214,
+  109,200,102,15,214,117,192,102,15,214,125,184,72,137,125,176,72,137,117,168,
+  72,137,85,160,72,137,77,152,76,137,69,144,76,137,77,136,255,73,188,237,237,
+  255,72,199,194,237,72,199,198,237,76,137,231,232,251,1,0,255,72,199,194,237,
+  72,199,198,252,255,252,255,252,255,252,255,76,137,231,232,251,1,0,255,72,
+  199,194,237,72,199,198,237,76,137,231,232,251,1,0,72,186,237,237,72,199,198,
+  252,255,252,255,252,255,252,255,76,137,231,232,251,1,1,255,72,137,8,72,199,
+  198,252,254,252,255,252,255,252,255,76,137,231,232,251,1,2,255,72,186,237,
+  237,72,199,198,0,0,0,0,76,137,231,232,251,1,1,255,72,137,8,255,102,15,214,
+  0,255,217,24,255,217,88,4,255,102,15,214,64,8,255,76,137,231,232,251,1,3,
+  255,15,182,201,72,137,206,76,137,231,232,251,1,4,255,15,182,201,255,15,190,
+  201,255,72,137,206,76,137,231,232,251,1,5,255,15,183,201,255,15,191,201,255,
+  72,137,206,76,137,231,232,251,1,6,255,72,185,237,237,72,199,194,237,72,199,
+  198,237,76,137,231,232,251,1,7,255,72,199,194,237,72,199,198,252,254,252,
+  255,252,255,252,255,76,137,231,232,251,1,0,72,185,237,237,72,199,194,252,
+  255,252,255,252,255,252,255,72,199,198,252,254,252,255,252,255,252,255,76,
+  137,231,232,251,1,8,72,137,68,36,32,72,199,198,252,252,252,255,252,255,252,
+  255,76,137,231,232,251,1,9,72,139,68,36,32,255,72,199,194,237,72,199,198,
+  252,254,252,255,252,255,252,255,76,137,231,232,251,1,0,72,185,237,237,72,
+  199,194,252,255,252,255,252,255,252,255,72,199,198,252,254,252,255,252,255,
+  252,255,76,137,231,232,251,1,10,137,68,36,32,72,199,198,252,252,252,255,252,
+  255,252,255,76,137,231,232,251,1,9,139,68,36,32,255,72,199,198,252,254,252,
+  255,252,255,252,255,76,137,231,232,251,1,9,255,72,199,198,252,255,252,255,
+  252,255,252,255,76,137,231,232,251,1,11,255,72,199,198,252,255,252,255,252,
+  255,252,255,76,137,231,232,251,1,12,255,137,68,36,32,72,199,198,252,253,252,
+  255,252,255,252,255,76,137,231,232,251,1,9,139,68,36,32,255,72,199,198,252,
+  255,252,255,252,255,252,255,76,137,231,232,251,1,13,255,72,199,198,252,255,
+  252,255,252,255,252,255,76,137,231,232,251,1,14,255,72,137,68,36,32,72,199,
+  198,252,253,252,255,252,255,252,255,76,137,231,232,251,1,9,72,139,68,36,32,
+  255,72,199,198,252,255,252,255,252,255,252,255,76,137,231,232,251,1,15,72,
+  137,68,36,32,72,199,198,252,253,252,255,252,255,252,255,76,137,231,232,251,
+  1,9,72,139,68,36,32,255,72,199,198,252,255,252,255,252,255,252,255,76,137,
+  231,232,251,1,16,102,15,214,68,36,32,72,199,198,252,253,252,255,252,255,252,
+  255,76,137,231,232,251,1,9,255,252,242,15,90,68,36,32,255,252,243,15,126,
+  68,36,32,255,72,199,198,252,255,252,255,252,255,252,255,76,137,231,232,251,
+  1,17,102,15,214,68,36,32,72,199,198,252,253,252,255,252,255,252,255,76,137,
+  231,232,251,1,9,252,243,15,126,68,36,32,255,72,199,198,252,255,252,255,252,
+  255,252,255,76,137,231,232,251,1,18,102,15,214,68,36,32,102,15,214,76,36,
+  40,72,199,198,252,253,252,255,252,255,252,255,76,137,231,232,251,1,9,252,
+  243,15,126,68,36,32,252,243,15,126,76,36,40,255,72,139,141,233,72,199,194,
+  252,255,252,255,252,255,252,255,76,137,230,72,137,207,232,251,1,18,72,131,
+  252,236,4,72,199,198,252,253,252,255,252,255,252,255,76,137,231,232,251,1,
+  9,255,76,139,101,252,248,72,137,252,236,93,194,236,255,85,72,137,229,65,84,
+  65,85,73,137,252,252,76,137,231,232,251,1,19,73,137,197,72,129,252,248,239,
+  255,15,141,244,248,102,184,0,0,72,190,237,237,76,137,231,232,251,1,20,248,
+  2,15,142,244,247,102,184,0,0,72,190,237,237,76,137,231,232,251,1,20,255,15,
+  141,244,247,102,184,0,0,72,190,237,237,76,137,231,232,251,1,20,255,248,1,
+  255,72,193,224,4,72,41,196,72,129,252,236,239,255,72,186,237,237,72,199,198,
+  0,0,0,0,76,137,231,232,251,1,1,72,131,252,236,16,255,72,185,237,237,72,199,
+  194,237,72,199,198,237,76,137,231,232,251,1,8,255,72,185,237,237,72,199,194,
+  237,72,199,198,237,76,137,231,232,251,1,21,255,72,185,237,237,72,199,194,
+  237,72,199,198,237,76,137,231,232,251,1,10,255,72,199,198,237,76,137,231,
+  232,251,1,12,255,15,182,192,255,15,190,192,255,15,183,192,255,15,191,192,
+  255,72,199,198,237,76,137,231,232,251,1,12,131,252,248,0,15,149,208,15,182,
+  192,255,72,199,198,237,76,137,231,232,251,1,11,255,72,199,198,237,76,137,
+  231,232,251,1,15,255,72,199,198,237,76,137,231,232,251,1,13,255,72,199,198,
+  237,76,137,231,232,251,1,14,255,72,199,198,237,76,137,231,232,251,1,16,255,
+  72,199,198,237,76,137,231,232,251,1,18,255,252,243,15,126,193,255,72,141,
+  132,253,36,233,72,131,252,236,4,72,199,194,237,76,137,230,72,137,199,232,
+  251,1,18,255,72,199,198,237,76,137,231,232,251,1,17,255,72,199,198,237,76,
+  137,231,232,251,1,17,137,4,36,217,4,36,255,137,20,36,217,4,36,255,72,137,
+  224,72,129,192,239,73,137,192,72,199,193,237,76,137,252,234,72,199,198,237,
+  76,137,231,232,251,1,22,255,72,137,224,72,129,192,239,73,137,192,72,199,193,
+  237,76,137,252,234,72,199,198,237,76,137,231,232,251,1,23,255,72,137,224,
+  72,129,192,239,73,137,193,73,199,192,237,72,199,193,237,76,137,252,234,72,
+  199,198,237,76,137,231,232,251,1,24,255,72,185,237,237,139,1,72,137,199,232,
+  251,1,25,255,72,131,196,32,255,252,243,15,126,188,253,36,233,255,252,243,
+  15,126,180,253,36,233,255,252,243,15,126,172,253,36,233,255,252,243,15,126,
+  164,253,36,233,255,252,243,15,126,156,253,36,233,255,252,243,15,126,148,253,
+  36,233,255,252,243,15,126,140,253,36,233,255,252,243,15,126,132,253,36,233,
+  255,76,139,140,253,36,233,255,76,139,132,253,36,233,255,72,139,140,253,36,
+  233,255,72,139,148,253,36,233,255,72,139,180,253,36,233,255,72,139,60,36,
+  255,72,129,196,239,255,176,8,255,232,251,1,26,72,131,252,236,48,255,72,137,
+  68,36,32,232,251,1,27,72,185,237,237,137,1,72,186,237,237,72,199,198,237,
+  76,137,231,232,251,1,1,72,139,76,36,32,72,137,8,184,1,0,0,0,76,139,109,252,
+  240,76,139,101,252,248,72,137,252,236,93,195,255,72,137,68,36,32,232,251,
+  1,27,72,185,237,237,137,1,72,139,68,36,32,72,137,198,76,137,231,232,251,1,
+  28,184,1,0,0,0,76,139,109,252,240,76,139,101,252,248,72,137,252,236,93,195,
+  255,72,137,68,36,32,232,251,1,27,72,185,237,237,137,1,72,186,237,237,72,199,
+  198,0,0,0,0,76,137,231,232,251,1,1,72,139,76,36,32,72,137,8,184,1,0,0,0,76,
+  139,109,252,240,76,139,101,252,248,72,137,252,236,93,195,255,102,15,214,68,
+  36,32,232,251,1,27,72,185,237,237,137,1,72,186,237,237,72,199,198,237,76,
+  137,231,232,251,1,1,72,139,76,36,32,72,137,8,184,1,0,0,0,76,139,109,252,240,
+  76,139,101,252,248,72,137,252,236,93,195,255,102,15,214,76,36,40,102,15,214,
+  68,36,32,232,251,1,27,72,185,237,237,137,1,72,186,237,237,72,199,198,237,
+  76,137,231,232,251,1,1,72,139,76,36,40,72,137,72,8,72,139,76,36,32,72,137,
+  8,184,1,0,0,0,76,139,109,252,240,76,139,101,252,248,72,137,252,236,93,195,
+  255,232,251,1,27,72,185,237,237,137,1,184,0,0,0,0,76,139,109,252,240,76,139,
+  101,252,248,72,137,252,236,93,195,255,15,182,192,137,68,36,32,232,251,1,27,
+  72,185,237,237,137,1,139,68,36,32,72,137,198,76,137,231,232,251,1,4,184,1,
+  0,0,0,76,139,109,252,240,76,139,101,252,248,72,137,252,236,93,195,255,137,
+  68,36,32,232,251,1,27,72,185,237,237,137,1,139,68,36,32,72,137,198,76,137,
+  231,232,251,1,5,184,1,0,0,0,76,139,109,252,240,76,139,101,252,248,72,137,
+  252,236,93,195,255,137,68,36,32,232,251,1,27,72,185,237,237,137,1,139,68,
+  36,32,72,137,198,76,137,231,232,251,1,6,184,1,0,0,0,76,139,109,252,240,76,
+  139,101,252,248,72,137,252,236,93,195,255,252,243,15,90,192,102,15,214,68,
+  36,32,232,251,1,27,72,185,237,237,137,1,252,243,15,126,68,36,32,76,137,231,
+  232,251,1,3,184,1,0,0,0,76,139,109,252,240,76,139,101,252,248,72,137,252,
+  236,93,195,255
 };
 
 static const char *const globnames[] = {
-  "lua_return_arg",
-  "lua_return_void",
-  "lua_return_double",
-  "lua_return_bool",
-  "lua_return_int",
-  "lua_return_uint",
-  "lua_return_long",
-  "lua_return_ulong",
-  "too_few_arguments",
-  "too_many_arguments",
-  "save_registers",
   (const char *)0
 };
 static const char *const extnames[] = {
-  "GetLastError",
+  "lua_rawgeti",
+  "push_cdata",
+  "lua_remove",
   "lua_pushnumber",
   "lua_pushboolean",
   "push_int",
   "push_uint",
-  "lua_pushinteger",
-  "luaL_error",
-  "lua_rawgeti",
-  "push_cdata",
-  "lua_remove",
   "lua_callk",
   "check_typed_pointer",
   "lua_settop",
@@ -168,14 +149,31 @@ static const char *const extnames[] = {
   "check_complex_float",
   "check_complex_double",
   "lua_gettop",
+  "luaL_error",
   "check_typed_cfunction",
   "unpack_varargs_float",
   "unpack_varargs_int",
   "unpack_varargs_stack_skip",
   "SetLastError",
   "FUNCTION",
+  "GetLastError",
+  "lua_pushinteger",
   (const char *)0
 };
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -229,42 +227,6 @@ void compile_globals(struct jit* jit, lua_State* L)
     /* Note the various call_* functions want 32 bytes of 16 byte aligned
      * stack
      */
-
-
-
-
-    /* the general idea for the return functions is:
-     * 1) Save return value on stack
-     * 2) Call get_errno (this trashes the registers hence #1)
-     * 3) Unpack return value from stack
-     * 4) Call lua push function
-     * 5) Set eax to number of returned args (0 or 1)
-     * 6) Call return which pops our stack frame
-     */
-
-    dasm_put(Dst, 0);
-
-    dasm_put(Dst, 24, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
-
-    dasm_put(Dst, 58, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
-
-    dasm_put(Dst, 95, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
-
-    dasm_put(Dst, 133, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
-
-    dasm_put(Dst, 168, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
-
-#if LUA_VERSION_NUM == 503
-    dasm_put(Dst, 203, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
-
-    dasm_put(Dst, 240, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
-#endif
-
-    dasm_put(Dst, 277, (unsigned int)((uintptr_t)(&"too few arguments")), (unsigned int)(((uintptr_t)(&"too few arguments"))>>32));
-
-    dasm_put(Dst, 295, (unsigned int)((uintptr_t)(&"too many arguments")), (unsigned int)(((uintptr_t)(&"too many arguments"))>>32));
-
-    dasm_put(Dst, 313);
 
     compile(Dst, L, NULL, LUA_NOREF);
 }
@@ -374,25 +336,25 @@ static void get_int(Dst_DECL, const struct ctype* ct, struct reg_alloc* reg, int
     /* grab the register from the shadow space */
 #ifdef _WIN64
     if (reg->regs < MAX_REGISTERS(ct)) {
-        dasm_put(Dst, 382, 16 + 8*reg->regs);
+        dasm_put(Dst, 0, 16 + 8*reg->regs);
         reg->regs++;
     }
 #elif __amd64__
     if (reg->ints < MAX_INT_REGISTERS(ct)) {
-        dasm_put(Dst, 382, - 80 - 8*reg->ints);
+        dasm_put(Dst, 0, - 80 - 8*reg->ints);
         reg->ints++;
     }
 #else
     if (!is_int64 && reg->ints < MAX_INT_REGISTERS(ct)) {
-        dasm_put(Dst, 383, - 8 - 4*reg->ints);
+        dasm_put(Dst, 1, - 8 - 4*reg->ints);
         reg->ints++;
     }
 #endif
     else if (is_int64) {
-        dasm_put(Dst, 382, reg->off);
+        dasm_put(Dst, 0, reg->off);
         reg->off += 8;
     } else {
-        dasm_put(Dst, 383, reg->off);
+        dasm_put(Dst, 1, reg->off);
         reg->off += 4;
     }
 }
@@ -401,17 +363,17 @@ static void add_int(Dst_DECL, const struct ctype* ct, struct reg_alloc* reg, int
 {
 #ifdef _WIN64
     if (reg->regs < MAX_REGISTERS(ct)) {
-        dasm_put(Dst, 387, 32 + 8*(reg->regs));
+        dasm_put(Dst, 5, 32 + 8*(reg->regs));
         reg->is_int[reg->regs++] = 1;
     }
 #elif __amd64__
     if (reg->ints < MAX_INT_REGISTERS(ct)) {
-        dasm_put(Dst, 387, 32 + 8*reg->ints);
+        dasm_put(Dst, 5, 32 + 8*reg->ints);
         reg->ints++;
     }
 #else
     if (!is_int64 && reg->ints < MAX_INT_REGISTERS(ct)) {
-        dasm_put(Dst, 387, 32 + 4*reg->ints);
+        dasm_put(Dst, 5, 32 + 4*reg->ints);
         reg->ints++;
     }
 #endif
@@ -422,10 +384,10 @@ static void add_int(Dst_DECL, const struct ctype* ct, struct reg_alloc* reg, int
         }
 #endif
         if (is_int64) {
-            dasm_put(Dst, 387, reg->off);
+            dasm_put(Dst, 5, reg->off);
             reg->off += 8;
         } else {
-            dasm_put(Dst, 388, reg->off);
+            dasm_put(Dst, 6, reg->off);
             reg->off += 4;
         }
     }
@@ -436,10 +398,10 @@ static void get_float(Dst_DECL, const struct ctype* ct, struct reg_alloc* reg, i
 #if !defined _WIN64 && !defined __amd64__
     assert(MAX_FLOAT_REGISTERS(ct) == 0);
     if (is_double) {
-        dasm_put(Dst, 394, reg->off);
+        dasm_put(Dst, 12, reg->off);
         reg->off += 8;
     } else {
-        dasm_put(Dst, 398, reg->off);
+        dasm_put(Dst, 16, reg->off);
         reg->off += 4;
     }
 #else
@@ -462,9 +424,9 @@ static void get_float(Dst_DECL, const struct ctype* ct, struct reg_alloc* reg, i
     }
 
     if (is_double) {
-        dasm_put(Dst, 402, off);
+        dasm_put(Dst, 20, off);
     } else {
-        dasm_put(Dst, 409, off);
+        dasm_put(Dst, 27, off);
     }
 #endif
 }
@@ -474,10 +436,10 @@ static void add_float(Dst_DECL, const struct ctype* ct, struct reg_alloc* reg, i
 #if !defined _WIN64 && !defined __amd64__
     assert(MAX_FLOAT_REGISTERS(ct) == 0);
     if (is_double) {
-        dasm_put(Dst, 416, reg->off);
+        dasm_put(Dst, 34, reg->off);
         reg->off += 8;
     } else {
-        dasm_put(Dst, 422, reg->off);
+        dasm_put(Dst, 40, reg->off);
         reg->off += 4;
     }
 #else
@@ -485,28 +447,28 @@ static void add_float(Dst_DECL, const struct ctype* ct, struct reg_alloc* reg, i
 #ifdef _WIN64
     if (reg->regs < MAX_REGISTERS(ct)) {
         if (is_double) {
-            dasm_put(Dst, 428, 32 + 8*(reg->regs));
+            dasm_put(Dst, 46, 32 + 8*(reg->regs));
         } else {
-            dasm_put(Dst, 436, 32 + 8*(reg->regs));
+            dasm_put(Dst, 54, 32 + 8*(reg->regs));
         }
         reg->is_float[reg->regs++] = 1;
     }
 #else
     if (reg->floats < MAX_FLOAT_REGISTERS(ct)) {
         if (is_double) {
-            dasm_put(Dst, 428, 32 + 8*(MAX_INT_REGISTERS(ct) + reg->floats));
+            dasm_put(Dst, 46, 32 + 8*(MAX_INT_REGISTERS(ct) + reg->floats));
         } else {
-            dasm_put(Dst, 436, 32 + 8*(MAX_INT_REGISTERS(ct) + reg->floats));
+            dasm_put(Dst, 54, 32 + 8*(MAX_INT_REGISTERS(ct) + reg->floats));
         }
         reg->floats++;
     }
 #endif
 
     else if (is_double) {
-        dasm_put(Dst, 428, reg->off);
+        dasm_put(Dst, 46, reg->off);
         reg->off += 8;
     } else {
-        dasm_put(Dst, 449, reg->off);
+        dasm_put(Dst, 67, reg->off);
         reg->off += 4;
     }
 #endif
@@ -562,21 +524,21 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
 
     // setup a stack frame to hold args for the call into lua_call
 
-    dasm_put(Dst, 462, 8 + 16 + 32 + REGISTER_STACK_SPACE(ct));
+    dasm_put(Dst, 80, 8 + 16 + 32 + REGISTER_STACK_SPACE(ct));
     if (ct->calling_convention == FAST_CALL) {
     }
 
     // hardcode the lua_State* value into the assembly
-    dasm_put(Dst, 477, (unsigned int)((uintptr_t)(L)), (unsigned int)(((uintptr_t)(L))>>32));
+    dasm_put(Dst, 157, (unsigned int)((uintptr_t)(L)), (unsigned int)(((uintptr_t)(L))>>32));
 
     /* get the upval table */
-    dasm_put(Dst, 482, ref, LUA_REGISTRYINDEX);
+    dasm_put(Dst, 162, ref, LUA_REGISTRYINDEX);
 
     /* get the lua function */
     lua_pushvalue(L, fidx);
     lua_rawseti(L, -2, ++num_upvals);
     assert(num_upvals == CALLBACK_FUNC_USR_IDX);
-    dasm_put(Dst, 498, num_upvals);
+    dasm_put(Dst, 178, num_upvals);
 
 #if !defined _WIN64 && !defined __amd64__
     lua_rawgeti(L, ct_usr, 0);
@@ -601,90 +563,90 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
             /* on the lua stack in the callback:
              * upval tbl, lua func, i-1 args
              */
-            dasm_put(Dst, 521, num_upvals-1, -i-1, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
+            dasm_put(Dst, 201, num_upvals-1, -i-1, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
             get_pointer(Dst, ct, &reg);
-            dasm_put(Dst, 559);
+            dasm_put(Dst, 239);
         } else {
             switch (mt->type) {
             case INT64_TYPE:
                 lua_getuservalue(L, -1);
                 lua_rawseti(L, -3, ++num_upvals); /* mt */
                 lua_pop(L, 1);
-                dasm_put(Dst, 581, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
+                dasm_put(Dst, 261, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
                 get_int(Dst, ct, &reg, 1);
-                dasm_put(Dst, 600);
+                dasm_put(Dst, 280);
                 break;
 
             case INTPTR_TYPE:
                 lua_getuservalue(L, -1);
                 lua_rawseti(L, -3, ++num_upvals); /* mt */
                 lua_pop(L, 1);
-                dasm_put(Dst, 581, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
+                dasm_put(Dst, 261, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
                 get_pointer(Dst, ct, &reg);
-                dasm_put(Dst, 600);
+                dasm_put(Dst, 280);
                 break;
 
             case COMPLEX_FLOAT_TYPE:
                 lua_pop(L, 1);
 #if defined _WIN64 || defined __amd64__
                 /* complex floats are two floats packed into a double */
-                dasm_put(Dst, 581, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
+                dasm_put(Dst, 261, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
                 get_float(Dst, ct, &reg, 1);
-                dasm_put(Dst, 604);
+                dasm_put(Dst, 284);
 #else
                 /* complex floats are real followed by imag on the stack */
-                dasm_put(Dst, 581, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
+                dasm_put(Dst, 261, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
                 get_float(Dst, ct, &reg, 0);
-                dasm_put(Dst, 609);
+                dasm_put(Dst, 289);
                 get_float(Dst, ct, &reg, 0);
-                dasm_put(Dst, 612);
+                dasm_put(Dst, 292);
 #endif
                 break;
 
             case COMPLEX_DOUBLE_TYPE:
                 lua_pop(L, 1);
-                dasm_put(Dst, 581, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
+                dasm_put(Dst, 261, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
                 /* real */
                 get_float(Dst, ct, &reg, 1);
-                dasm_put(Dst, 604);
+                dasm_put(Dst, 284);
                 /* imag */
                 get_float(Dst, ct, &reg, 1);
-                dasm_put(Dst, 616);
+                dasm_put(Dst, 296);
                 break;
 
             case FLOAT_TYPE:
             case DOUBLE_TYPE:
                 lua_pop(L, 1);
                 get_float(Dst, ct, &reg, mt->type == DOUBLE_TYPE);
-                dasm_put(Dst, 622);
+                dasm_put(Dst, 302);
                 break;
 
             case BOOL_TYPE:
                 lua_pop(L, 1);
                 get_int(Dst, ct, &reg, 0);
-                dasm_put(Dst, 630);
+                dasm_put(Dst, 310);
                 break;
 
             case INT8_TYPE:
                 lua_pop(L, 1);
                 get_int(Dst, ct, &reg, 0);
                 if (mt->is_unsigned) {
-                    dasm_put(Dst, 644);
+                    dasm_put(Dst, 324);
                 } else {
-                    dasm_put(Dst, 648);
+                    dasm_put(Dst, 328);
                 }
-                dasm_put(Dst, 652);
+                dasm_put(Dst, 332);
                 break;
 
             case INT16_TYPE:
                 lua_pop(L, 1);
                 get_int(Dst, ct, &reg, 0);
                 if (mt->is_unsigned) {
-                    dasm_put(Dst, 663);
+                    dasm_put(Dst, 343);
                 } else {
-                    dasm_put(Dst, 667);
+                    dasm_put(Dst, 347);
                 }
-                dasm_put(Dst, 652);
+                dasm_put(Dst, 332);
                 break;
 
             case ENUM_TYPE:
@@ -692,9 +654,9 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
                 lua_pop(L, 1);
                 get_int(Dst, ct, &reg, 0);
                 if (mt->is_unsigned) {
-                    dasm_put(Dst, 671);
+                    dasm_put(Dst, 351);
                 } else {
-                    dasm_put(Dst, 652);
+                    dasm_put(Dst, 332);
                 }
                 break;
 
@@ -707,7 +669,7 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
     lua_rawgeti(L, ct_usr, 0);
     mt = (const struct ctype*) lua_touserdata(L, -1);
 
-    dasm_put(Dst, 682, (unsigned int)((uintptr_t)(0)), (unsigned int)(((uintptr_t)(0))>>32), (mt->pointers || mt->is_reference || mt->type != VOID_TYPE) ? 1 : 0, nargs);
+    dasm_put(Dst, 362, (unsigned int)((uintptr_t)(0)), (unsigned int)(((uintptr_t)(0))>>32), (mt->pointers || mt->is_reference || mt->type != VOID_TYPE) ? 1 : 0, nargs);
 
     // Unpack the return argument if not "void", also clean-up the lua stack
     // to remove the return argument and bind table. Use lua_settop rather
@@ -716,7 +678,7 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
         lua_getuservalue(L, -1);
         lua_rawseti(L, -3, ++num_upvals); /* usr value */
         lua_rawseti(L, -2, ++num_upvals); /* mt */
-        dasm_put(Dst, 702, num_upvals-1, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
+        dasm_put(Dst, 382, num_upvals-1, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
 
     } else {
         switch (mt->type) {
@@ -724,12 +686,12 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
             lua_getuservalue(L, -1);
             lua_rawseti(L, -3, ++num_upvals); /* usr value */
             lua_rawseti(L, -2, ++num_upvals); /* mt */
-            dasm_put(Dst, 786, num_upvals-1, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
+            dasm_put(Dst, 466, num_upvals-1, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
             break;
 
         case VOID_TYPE:
             lua_pop(L, 1);
-            dasm_put(Dst, 868);
+            dasm_put(Dst, 548);
             break;
 
         case BOOL_TYPE:
@@ -738,38 +700,38 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
         case INT32_TYPE:
             lua_pop(L, 1);
             if (mt->is_unsigned) {
-                dasm_put(Dst, 887);
+                dasm_put(Dst, 567);
             } else {
-                dasm_put(Dst, 906);
+                dasm_put(Dst, 586);
             }
-            dasm_put(Dst, 925);
+            dasm_put(Dst, 605);
             break;
 
         case INT64_TYPE:
             lua_pop(L, 1);
 
             if (mt->is_unsigned) {
-                dasm_put(Dst, 952);
+                dasm_put(Dst, 632);
             } else {
-                dasm_put(Dst, 971);
+                dasm_put(Dst, 651);
             }
 
-            dasm_put(Dst, 990);
+            dasm_put(Dst, 670);
             break;
 
         case INTPTR_TYPE:
             lua_pop(L, 1);
-            dasm_put(Dst, 1019);
+            dasm_put(Dst, 699);
             break;
 
         case FLOAT_TYPE:
         case DOUBLE_TYPE:
             lua_pop(L, 1);
-            dasm_put(Dst, 1066);
+            dasm_put(Dst, 746);
             if (mt->type == FLOAT_TYPE) {
-                dasm_put(Dst, 1109);
+                dasm_put(Dst, 789);
             } else {
-                dasm_put(Dst, 1117);
+                dasm_put(Dst, 797);
             }
             break;
 
@@ -780,7 +742,7 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
 #endif
             /* on 64 bit complex floats are two floats packed into a double,
              * on 32 bit returned complex floats use eax and edx */
-            dasm_put(Dst, 1125);
+            dasm_put(Dst, 805);
             break;
 
         case COMPLEX_DOUBLE_TYPE:
@@ -793,9 +755,9 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
              * the returned arg is stored which is popped by the called
              * function */
 #if defined _WIN64 || defined __amd64__
-            dasm_put(Dst, 1175);
+            dasm_put(Dst, 855);
 #else
-            dasm_put(Dst, 1238, hidden_arg_off);
+            dasm_put(Dst, 918, hidden_arg_off);
 #endif
             break;
 
@@ -804,7 +766,7 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
         }
     }
 
-    dasm_put(Dst, 1287, x86_return_size(L, ct_usr, ct));
+    dasm_put(Dst, 967, x86_return_size(L, ct_usr, ct));
 
     lua_pop(L, 1); /* upval table - already in registry */
     assert(lua_gettop(L) == top);
@@ -846,15 +808,18 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
         luaL_error(L, "vararg is only allowed with the c calling convention");
     }
 
-    dasm_put(Dst, 1300, nargs);
-
+    dasm_put(Dst, 980, nargs);
     if (!ct->has_var_arg) {
-        dasm_put(Dst, 1332);
+        dasm_put(Dst, 1008, (unsigned int)((uintptr_t)(&"too few arguments")), (unsigned int)(((uintptr_t)(&"too few arguments"))>>32), (unsigned int)((uintptr_t)(&"too many arguments")), (unsigned int)(((uintptr_t)(&"too many arguments"))>>32));
+    } else {
+        dasm_put(Dst, 1049, (unsigned int)((uintptr_t)(&"too few arguments")), (unsigned int)(((uintptr_t)(&"too few arguments"))>>32));
     }
+
+    dasm_put(Dst, 1069);
 
     /* no need to zero extend eax returned by lua_gettop to rax as x86-64
      * preguarentees that the upper 32 bits will be zero */
-    dasm_put(Dst, 1337, 32 + REGISTER_STACK_SPACE(ct));
+    dasm_put(Dst, 1072, 32 + REGISTER_STACK_SPACE(ct));
 
 #if !defined _WIN64 && !defined __amd64__
     /* Returned complex doubles require a hidden first parameter where the
@@ -865,7 +830,7 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
         /* we can allocate more space for arguments as long as no add_*
          * function has been called yet, mbr_ct will be added as an upvalue in
          * the return processing later */
-        dasm_put(Dst, 1350, (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32));
+        dasm_put(Dst, 1085, (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32));
         add_pointer(Dst, ct, &reg);
     }
     lua_pop(L, 1);
@@ -878,80 +843,80 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
         if (mbr_ct->pointers || mbr_ct->is_reference) {
             lua_getuservalue(L, -1);
             num_upvals += 2;
-            dasm_put(Dst, 1374, (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals), i);
+            dasm_put(Dst, 1109, (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals), i);
             add_pointer(Dst, ct, &reg);
         } else {
             switch (mbr_ct->type) {
             case FUNCTION_PTR_TYPE:
                 lua_getuservalue(L, -1);
                 num_upvals += 2;
-                dasm_put(Dst, 1394, (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals), i);
+                dasm_put(Dst, 1129, (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals), i);
                 add_pointer(Dst, ct, &reg);
                 break;
 
             case ENUM_TYPE:
                 lua_getuservalue(L, -1);
                 num_upvals += 2;
-                dasm_put(Dst, 1414, (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals), i);
+                dasm_put(Dst, 1149, (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals), i);
                 add_int(Dst, ct, &reg, 0);
                 break;
 
             case INT8_TYPE:
-                dasm_put(Dst, 1434, i);
+                dasm_put(Dst, 1169, i);
                 if (mbr_ct->is_unsigned) {
-                    dasm_put(Dst, 1446);
+                    dasm_put(Dst, 1181);
                 } else {
-                    dasm_put(Dst, 1450);
+                    dasm_put(Dst, 1185);
                 }
                 add_int(Dst, ct, &reg, 0);
                 lua_pop(L, 1);
                 break;
 
             case INT16_TYPE:
-                dasm_put(Dst, 1434, i);
+                dasm_put(Dst, 1169, i);
                 if (mbr_ct->is_unsigned) {
-                    dasm_put(Dst, 1454);
+                    dasm_put(Dst, 1189);
                 } else {
-                    dasm_put(Dst, 1458);
+                    dasm_put(Dst, 1193);
                 }
                 add_int(Dst, ct, &reg, 0);
                 lua_pop(L, 1);
                 break;
 
             case BOOL_TYPE:
-                dasm_put(Dst, 1462, i);
+                dasm_put(Dst, 1197, i);
                 add_int(Dst, ct, &reg, 0);
                 lua_pop(L, 1);
                 break;
 
             case INT32_TYPE:
                 if (mbr_ct->is_unsigned) {
-                    dasm_put(Dst, 1484, i);
+                    dasm_put(Dst, 1219, i);
                 } else {
-                    dasm_put(Dst, 1434, i);
+                    dasm_put(Dst, 1169, i);
                 }
                 add_int(Dst, ct, &reg, 0);
                 lua_pop(L, 1);
                 break;
 
             case INTPTR_TYPE:
-                dasm_put(Dst, 1496, i);
+                dasm_put(Dst, 1231, i);
                 add_pointer(Dst, ct, &reg);
                 lua_pop(L, 1);
                 break;
 
             case INT64_TYPE:
                 if (mbr_ct->is_unsigned) {
-                    dasm_put(Dst, 1508, i);
+                    dasm_put(Dst, 1243, i);
                 } else {
-                    dasm_put(Dst, 1520, i);
+                    dasm_put(Dst, 1255, i);
                 }
                 add_int(Dst, ct, &reg, 1);
                 lua_pop(L, 1);
                 break;
 
             case DOUBLE_TYPE:
-                dasm_put(Dst, 1532, i);
+                dasm_put(Dst, 1267, i);
                 add_float(Dst, ct, &reg, 1);
                 lua_pop(L, 1);
                 break;
@@ -962,33 +927,33 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
                  * the returned arg is stored (this is popped by the called
                  * function) */
 #if defined _WIN64 || defined __amd64__
-                dasm_put(Dst, 1544, i);
+                dasm_put(Dst, 1279, i);
                 add_float(Dst, ct, &reg, 1);
-                dasm_put(Dst, 1556);
+                dasm_put(Dst, 1291);
                 add_float(Dst, ct, &reg, 1);
 #else
-                dasm_put(Dst, 1562, reg.off, i);
+                dasm_put(Dst, 1297, reg.off, i);
                 reg.off += 16;
 #endif
                 lua_pop(L, 1);
                 break;
 
             case FLOAT_TYPE:
-                dasm_put(Dst, 1532, i);
+                dasm_put(Dst, 1267, i);
                 add_float(Dst, ct, &reg, 0);
                 lua_pop(L, 1);
                 break;
 
             case COMPLEX_FLOAT_TYPE:
 #if defined _WIN64 || defined __amd64__
-                dasm_put(Dst, 1588, i);
+                dasm_put(Dst, 1323, i);
                 /* complex floats are two floats packed into a double */
                 add_float(Dst, ct, &reg, 1);
 #else
                 /* returned complex floats use eax and edx */
-                dasm_put(Dst, 1600, i);
+                dasm_put(Dst, 1335, i);
                 add_float(Dst, ct, &reg, 0);
-                dasm_put(Dst, 1618);
+                dasm_put(Dst, 1353);
                 add_float(Dst, ct, &reg, 0);
 #endif
                 lua_pop(L, 1);
@@ -1013,14 +978,14 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
         reg.regs = MAX_REGISTERS(ct);
 #elif defined __amd64__
         if (reg.floats < MAX_FLOAT_REGISTERS(ct)) {
-            dasm_put(Dst, 1625, 32 + 8*(MAX_INT_REGISTERS(ct) + reg.floats), MAX_FLOAT_REGISTERS(ct) - reg.floats, nargs+1);
+            dasm_put(Dst, 1360, 32 + 8*(MAX_INT_REGISTERS(ct) + reg.floats), MAX_FLOAT_REGISTERS(ct) - reg.floats, nargs+1);
         }
 
         if (reg.ints < MAX_INT_REGISTERS(ct)) {
-            dasm_put(Dst, 1655, 32 + 8*(reg.ints), MAX_INT_REGISTERS(ct) - reg.ints, nargs+1);
+            dasm_put(Dst, 1390, 32 + 8*(reg.ints), MAX_INT_REGISTERS(ct) - reg.ints, nargs+1);
         }
 
-        dasm_put(Dst, 1685, reg.off, MAX_FLOAT_REGISTERS(ct) - reg.floats, MAX_INT_REGISTERS(ct) - reg.ints, nargs+1);
+        dasm_put(Dst, 1420, reg.off, MAX_FLOAT_REGISTERS(ct) - reg.floats, MAX_INT_REGISTERS(ct) - reg.ints, nargs+1);
 
         reg.floats = MAX_FLOAT_REGISTERS(ct);
         reg.ints = MAX_INT_REGISTERS(ct);
@@ -1028,10 +993,10 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
 #endif
     }
 
-    dasm_put(Dst, 1719, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
+    dasm_put(Dst, 1454, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
 
     /* remove the stack space to call local functions */
-    dasm_put(Dst, 1733);
+    dasm_put(Dst, 1468);
 
 #ifdef _WIN64
     switch (reg.regs) {
@@ -1065,43 +1030,43 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
 #elif defined __amd64__
     switch (reg.floats) {
     case 8:
-        dasm_put(Dst, 1738, 8*(MAX_INT_REGISTERS(ct)+7));
+        dasm_put(Dst, 1473, 8*(MAX_INT_REGISTERS(ct)+7));
     case 7:
-        dasm_put(Dst, 1747, 8*(MAX_INT_REGISTERS(ct)+6));
+        dasm_put(Dst, 1482, 8*(MAX_INT_REGISTERS(ct)+6));
     case 6:
-        dasm_put(Dst, 1756, 8*(MAX_INT_REGISTERS(ct)+5));
+        dasm_put(Dst, 1491, 8*(MAX_INT_REGISTERS(ct)+5));
     case 5:
-        dasm_put(Dst, 1765, 8*(MAX_INT_REGISTERS(ct)+4));
+        dasm_put(Dst, 1500, 8*(MAX_INT_REGISTERS(ct)+4));
     case 4:
-        dasm_put(Dst, 1774, 8*(MAX_INT_REGISTERS(ct)+3));
+        dasm_put(Dst, 1509, 8*(MAX_INT_REGISTERS(ct)+3));
     case 3:
-        dasm_put(Dst, 1783, 8*(MAX_INT_REGISTERS(ct)+2));
+        dasm_put(Dst, 1518, 8*(MAX_INT_REGISTERS(ct)+2));
     case 2:
-        dasm_put(Dst, 1792, 8*(MAX_INT_REGISTERS(ct)+1));
+        dasm_put(Dst, 1527, 8*(MAX_INT_REGISTERS(ct)+1));
     case 1:
-        dasm_put(Dst, 1801, 8*(MAX_INT_REGISTERS(ct)));
+        dasm_put(Dst, 1536, 8*(MAX_INT_REGISTERS(ct)));
     case 0:
         break;
     }
 
     switch (reg.ints) {
     case 6:
-        dasm_put(Dst, 1810, 8*5);
+        dasm_put(Dst, 1545, 8*5);
     case 5:
-        dasm_put(Dst, 1817, 8*4);
+        dasm_put(Dst, 1552, 8*4);
     case 4:
-        dasm_put(Dst, 1824, 8*3);
+        dasm_put(Dst, 1559, 8*3);
     case 3:
-        dasm_put(Dst, 1831, 8*2);
+        dasm_put(Dst, 1566, 8*2);
     case 2:
-        dasm_put(Dst, 1838, 8*1);
+        dasm_put(Dst, 1573, 8*1);
     case 1:
-        dasm_put(Dst, 1845);
+        dasm_put(Dst, 1580);
     case 0:
         break;
     }
 
-    dasm_put(Dst, 1850, REGISTER_STACK_SPACE(ct));
+    dasm_put(Dst, 1585, REGISTER_STACK_SPACE(ct));
 #else
     if (ct->calling_convention == FAST_CALL) {
         switch (reg.ints) {
@@ -1119,11 +1084,11 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
         /* al stores an upper limit on the number of float register, note that
          * its allowed to be more than the actual number of float registers used as
          * long as its 0-8 */
-        dasm_put(Dst, 1855);
+        dasm_put(Dst, 1590);
     }
 #endif
 
-    dasm_put(Dst, 1858);
+    dasm_put(Dst, 1593);
 
     /* note on windows X86 the stack may be only aligned to 4 (stdcall will
      * have popped a multiple of 4 bytes), but we don't need 16 byte alignment on
@@ -1136,90 +1101,90 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
     if (mbr_ct->pointers || mbr_ct->is_reference || mbr_ct->type == INTPTR_TYPE) {
         lua_getuservalue(L, -1);
         num_upvals += 2;
-        dasm_put(Dst, 1868, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32), (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals));
+        dasm_put(Dst, 1603, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32), (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals));
 
     } else {
         switch (mbr_ct->type) {
         case FUNCTION_PTR_TYPE:
             lua_getuservalue(L, -1);
             num_upvals += 2;
-            dasm_put(Dst, 1868, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32), (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals));
+            dasm_put(Dst, 1603, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32), (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals));
             break;
 
         case INT64_TYPE:
 #if LUA_VERSION_NUM == 503
             lua_pop(L, 1);
             if (mbr_ct->is_unsigned) {
-                dasm_put(Dst, 1911);
+                dasm_put(Dst, 1663, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
             } else {
-                dasm_put(Dst, 1916);
+                dasm_put(Dst, 1663, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
             }
 #else
             num_upvals++;
-            dasm_put(Dst, 1921, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32), (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32));
+            dasm_put(Dst, 1715, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32), (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32));
 #endif
             break;
 
         case COMPLEX_FLOAT_TYPE:
             lua_getuservalue(L, -1);
             num_upvals += 2;
-            dasm_put(Dst, 1967, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32), (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals));
+            dasm_put(Dst, 1778, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32), (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals));
             break;
 
         case COMPLEX_DOUBLE_TYPE:
             lua_getuservalue(L, -1);
             num_upvals += 2;
-            dasm_put(Dst, 2011, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32), (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals));
+            dasm_put(Dst, 1839, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32), (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals));
             break;
 
         case VOID_TYPE:
             lua_pop(L, 1);
-            dasm_put(Dst, 2070);
+            dasm_put(Dst, 1915, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
             break;
 
         case BOOL_TYPE:
             lua_pop(L, 1);
-            dasm_put(Dst, 2075);
+            dasm_put(Dst, 1947, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
             break;
 
         case INT8_TYPE:
             lua_pop(L, 1);
             if (mbr_ct->is_unsigned) {
-                dasm_put(Dst, 1446);
+                dasm_put(Dst, 1181);
             } else {
-                dasm_put(Dst, 1450);
+                dasm_put(Dst, 1185);
             }
-            dasm_put(Dst, 2080);
+            dasm_put(Dst, 2000, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
             break;
 
         case INT16_TYPE:
             lua_pop(L, 1);
             if (mbr_ct->is_unsigned) {
-                dasm_put(Dst, 1454);
+                dasm_put(Dst, 1189);
             } else {
-                dasm_put(Dst, 1458);
+                dasm_put(Dst, 1193);
             }
-            dasm_put(Dst, 2080);
+            dasm_put(Dst, 2000, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
             break;
 
         case INT32_TYPE:
         case ENUM_TYPE:
             lua_pop(L, 1);
             if (mbr_ct->is_unsigned) {
-                dasm_put(Dst, 2085);
+                dasm_put(Dst, 2050, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
             } else {
-                dasm_put(Dst, 2080);
+                dasm_put(Dst, 2000, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
             }
             break;
 
         case FLOAT_TYPE:
             lua_pop(L, 1);
-            dasm_put(Dst, 2090);
+            dasm_put(Dst, 2100, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
             break;
 
         case DOUBLE_TYPE:
             lua_pop(L, 1);
-            dasm_put(Dst, 2095);
+            dasm_put(Dst, 2105, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
             break;
 
         default:

--- a/call_x64win.h
+++ b/call_x64win.h
@@ -18,139 +18,121 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-static const unsigned char build_actionlist[2043] = {
-  248,10,184,1,0.0,0.0,0.0,76,139,109,252,240,76,139,101,252,248,72,137,252,
-  236,93,195,255,248,11,232,251,1,0,72,185,237,237,137,1,184,0,0.0,0.0,0.0,
-  76,139,109,252,240,76,139,101,252,248,72,137,252,236,93,195,255,248,12,102.0,
-  15.0,214,68,36,32,232,251,1,0,72,185,237,237,137,1,252,243.0,15.0,126,76,
-  36,32,76,137,225,232,251,1,1,252,233,244,10,255,248,13,15.0,182,192,137,68,
-  36,32,232,251,1,0,72,185,237,237,137,1,139,68,36,32,72,137,194,76,137,225,
-  232,251,1,2,252,233,244,10,255,248,14,137,68,36,32,232,251,1,0,72,185,237,
-  237,137,1,139,68,36,32,72,137,194,76,137,225,232,251,1,3,252,233,244,10,255,
-  248,15,137,68,36,32,232,251,1,0,72,185,237,237,137,1,139,68,36,32,72,137,
-  194,76,137,225,232,251,1,4,252,233,244,10,255,248,16,72,137,68,36,32,232,
-  251,1,0,72,185,237,237,137,1,72,139,68,36,32,72,137,194,76,137,225,232,251,
-  1,5,252,233,244,10,255,248,17,72,137,68,36,32,232,251,1,0,72,185,237,237,
-  137,1,72,139,68,36,32,72,137,194,76,137,225,232,251,1,5,252,233,244,10,255,
-  248,18,102,184,0,0.0,72,186,237,237,76,137,225,232,251,1,6,255,248,19,102,
-  184,0,0.0,72,186,237,237,76,137,225,232,251,1,6,255,248,20,72,137,77,16,72,
-  137,85,24,76,137,69,32,76,137,77,40,102.0,15.0,214,69,252,240,102.0,15.0,
-  214,77,232,102.0,15.0,214,85,224,102.0,15.0,214,93,216,195,255,72,139,141,
-  233,255,72,137,132,253,36,233,255,221.0,133,233,255,217.0,133,233,255,252,
-  243.0,15.0,126,133,233,255,252,243.0,15.0,90,133,233,255,221.0,156,253,36,
-  233,255,217.0,156,253,36,233,255,102.0,15.0,214,132,253,36,233,255,252,242.0,
-  15.0,90,192,102.0,15.0,214,132,253,36,233,255,252,242.0,15.0,90,192,102.0,
-  15.0,126,132,253,36,233,255,85,72,137,229,65,84,72,129.0,252,236,239,232,
-  244,20,255,73,188,237,237,255,73,199.0,192,237,72,199.0,194,237,76,137,225,
-  232,251,1,7,255,73,199.0,192,237,72,199.0,194,252,255,252,255.0,252,255.0,
-  252,255.0,76,137,225,232,251,1,7,255,73,199.0,192,237,72,199.0,194,237,76,
-  137,225,232,251,1,7,73,184,237,237,72,199.0,194,252,255,252,255.0,252,255.0,
-  252,255.0,76,137,225,232,251,1,8,255,72,137,8,72,199.0,194,252,254,252,255.0,
-  252,255.0,252,255.0,76,137,225,232,251,1,9,255,73,184,237,237,72,199.0,194,
-  0,0.0,0.0,0.0,76,137,225,232,251,1,8,255,72,137,8,255,102.0,15.0,214,0,255,
-  217.0,24,255,217.0,88,4,255,102.0,15.0,214,64,8,255,252,243.0,15.0,126,200,
-  76,137,225,232,251,1,1,255,15.0,182,201,72,137,202,76,137,225,232,251,1,2,
-  255,15.0,182,201,255,15.0,190,201,255,72,137,202,76,137,225,232,251,1,3,255,
-  15.0,183,201,255,15.0,191,201,255,72,137,202,76,137,225,232,251,1,4,255,73,
-  185,237,237,73,199.0,192,237,72,199.0,194,237,76,137,225,232,251,1,10,255,
-  73,199.0,192,237,72,199.0,194,252,254,252,255.0,252,255.0,252,255.0,76,137,
-  225,232,251,1,7,73,185,237,237,73,199.0,192,252,255,252,255.0,252,255.0,252,
-  255.0,72,199.0,194,252,254,252,255.0,252,255.0,252,255.0,76,137,225,232,251,
-  1,11,72,137,68,36,32,72,199.0,194,252,252,252,255.0,252,255.0,252,255.0,76,
-  137,225,232,251,1,12,72,139,68,36,32,255,73,199.0,192,237,72,199.0,194,252,
-  254,252,255.0,252,255.0,252,255.0,76,137,225,232,251,1,7,73,185,237,237,73,
-  199.0,192,252,255,252,255.0,252,255.0,252,255.0,72,199.0,194,252,254,252,
-  255.0,252,255.0,252,255.0,76,137,225,232,251,1,13,137,68,36,32,72,199.0,194,
-  252,252,252,255.0,252,255.0,252,255.0,76,137,225,232,251,1,12,139,68,36,32,
-  255,72,199.0,194,252,254,252,255.0,252,255.0,252,255.0,76,137,225,232,251,
-  1,12,255,72,199.0,194,252,255,252,255.0,252,255.0,252,255.0,76,137,225,232,
-  251,1,14,255,72,199.0,194,252,255,252,255.0,252,255.0,252,255.0,76,137,225,
-  232,251,1,15,255,137,68,36,32,72,199.0,194,252,253,252,255.0,252,255.0,252,
-  255.0,76,137,225,232,251,1,12,139,68,36,32,255,72,199.0,194,252,255,252,255.0,
-  252,255.0,252,255.0,76,137,225,232,251,1,16,255,72,199.0,194,252,255,252,
-  255.0,252,255.0,252,255.0,76,137,225,232,251,1,17,255,72,137,68,36,32,72,
-  199.0,194,252,253,252,255.0,252,255.0,252,255.0,76,137,225,232,251,1,12,72,
-  139,68,36,32,255,72,199.0,194,252,255,252,255.0,252,255.0,252,255.0,76,137,
-  225,232,251,1,18,72,137,68,36,32,72,199.0,194,252,253,252,255.0,252,255.0,
-  252,255.0,76,137,225,232,251,1,12,72,139,68,36,32,255,72,199.0,194,252,255,
-  252,255.0,252,255.0,252,255.0,76,137,225,232,251,1,19,102.0,15.0,214,68,36,
-  32,72,199.0,194,252,253,252,255.0,252,255.0,252,255.0,76,137,225,232,251,
-  1,12,255,252,242.0,15.0,90,68,36,32,255,252,243.0,15.0,126,68,36,32,255,72,
-  199.0,194,252,255,252,255.0,252,255.0,252,255.0,76,137,225,232,251,1,20,102.0,
-  15.0,214,68,36,32,72,199.0,194,252,253,252,255.0,252,255.0,252,255.0,76,137,
-  225,232,251,1,12,252,243.0,15.0,126,68,36,32,255,72,199.0,194,252,255,252,
-  255.0,252,255.0,252,255.0,76,137,225,232,251,1,21,102.0,15.0,214,68,36,32,
-  102.0,15.0,214,76,36,40,72,199.0,194,252,253,252,255.0,252,255.0,252,255.0,
-  76,137,225,232,251,1,12,252,243.0,15.0,126,68,36,32,252,243.0,15.0,126,76,
-  36,40,255,72,139,141,233,73,199.0,192,252,255,252,255.0,252,255.0,252,255.0,
-  76,137,226,72,137,201,232,251,1,21,72,131.0,252,236,4,72,199.0,194,252,253,
-  252,255.0,252,255.0,252,255.0,76,137,225,232,251,1,12,255,76,139,101,252,
-  248,72,137,252,236,93,194,236,255,85,72,137,229,65,84,65,85,73,137,204,72,
-  131.0,252,236,32,76,137,225,232,251,1,22,73,137,197,72,129.0,252,248,239,
-  15.0,140,244,18,255,15.0,143,244,19,255,72,193.0,224,4,72,41,196,72,129.0,
-  252,236,239,255,73,184,237,237,72,199.0,194,0,0.0,0.0,0.0,76,137,225,232,
-  251,1,8,72,131.0,252,236,16,255,73,185,237,237,73,199.0,192,237,72,199.0,
-  194,237,76,137,225,232,251,1,11,255,73,185,237,237,73,199.0,192,237,72,199.0,
-  194,237,76,137,225,232,251,1,23,255,73,185,237,237,73,199.0,192,237,72,199.0,
-  194,237,76,137,225,232,251,1,13,255,72,199.0,194,237,76,137,225,232,251,1,
-  15,255,15.0,182,192,255,15.0,190,192,255,15.0,183,192,255,15.0,191,192,255,
-  72,199.0,194,237,76,137,225,232,251,1,15,131.0,252,248,0,15.0,149.0,208,15.0,
-  182,192,255,72,199.0,194,237,76,137,225,232,251,1,14,255,72,199.0,194,237,
-  76,137,225,232,251,1,18,255,72,199.0,194,237,76,137,225,232,251,1,16,255,
-  72,199.0,194,237,76,137,225,232,251,1,17,255,72,199.0,194,237,76,137,225,
-  232,251,1,19,255,72,199.0,194,237,76,137,225,232,251,1,21,255,252,243.0,15.0,
-  126,193,255,72,141,132,253,36,233,72,131.0,252,236,4,73,199.0,192,237,76,
-  137,226,72,137,193,232,251,1,21,255,72,199.0,194,237,76,137,225,232,251,1,
-  20,255,72,199.0,194,237,76,137,225,232,251,1,20,137,4,36,217.0,4,36,255,137,
-  20,36,217.0,4,36,255,73,129.0,252,253,239,15.0,142,244,247.0,72,137,224,72,
-  129.0,192,239,73,137,193,77,137,232,72,199.0,194,237,76,137,225,232,251,1,
-  24,72,137,224,72,129.0,192,239,73,137,193,73,199.0,192,237,72,199.0,194,237,
-  76,137,225,232,251,1,25,252,233,244,248.0,248,1,72,137,224,72,129.0,192,239,
-  73,137,193,77,137,232,72,199.0,194,237,76,137,225,232,251,1,25,248,2,255,
-  72,137,224,72,129.0,192,239,73,137,193,77,137,232,72,199.0,194,237,76,137,
-  225,232,251,1,24,255,72,185,237,237,139,1,72,137,193,232,251,1,26,255,72,
-  131.0,196,32,255,252,243.0,15.0,126,156,253,36,233,255,76,139,140,253,36,
-  233,255,252,243.0,15.0,126,148,253,36,233,255,76,139,132,253,36,233,255,252,
-  243.0,15.0,126,140,253,36,233,255,72,139,148,253,36,233,255,252,243.0,15.0,
-  126,4,36,255,72,139,12,36,255,232,251,1,27,72,131.0,252,236,48,255,72,137,
-  68,36,32,232,251,1,0,72,185,237,237,137,1,73,184,237,237,72,199.0,194,237,
-  76,137,225,232,251,1,8,72,139,76,36,32,72,137,8,252,233,244,10,255,252,233,
-  244,17,255,252,233,244,16,255,72,137,68,36,32,232,251,1,0,72,185,237,237,
-  137,1,73,184,237,237,72,199.0,194,0,0.0,0.0,0.0,76,137,225,232,251,1,8,72,
-  139,76,36,32,72,137,8,252,233,244,10,255,102.0,15.0,214,68,36,32,232,251,
-  1,0,72,185,237,237,137,1,73,184,237,237,72,199.0,194,237,76,137,225,232,251,
-  1,8,72,139,76,36,32,72,137,8,252,233,244,10,255,102.0,15.0,214,76,36,40,102.0,
-  15.0,214,68,36,32,232,251,1,0,72,185,237,237,137,1,73,184,237,237,72,199.0,
-  194,237,76,137,225,232,251,1,8,72,139,76,36,40,72,137,72,8,72,139,76,36,32,
-  72,137,8,252,233,244,10,255,252,233,244,11,255,252,233,244,13,255,252,233,
-  244,14,255,252,233,244,15,255,252,243.0,15.0,90,192,252,233,244,12,255
+static const unsigned char build_actionlist[2100] = {
+  72,139,141,233,255,72,137,132,253,36,233,255,221,133,233,255,217,133,233,
+  255,252,243,15,126,133,233,255,252,243,15,90,133,233,255,221,156,253,36,233,
+  255,217,156,253,36,233,255,102,15,214,132,253,36,233,255,252,242,15,90,192,
+  102,15,214,132,253,36,233,255,252,242,15,90,192,102,15,126,132,253,36,233,
+  255,85,72,137,229,65,84,72,129,252,236,239,72,137,77,16,72,137,85,24,76,137,
+  69,32,76,137,77,40,102,15,214,69,252,240,102,15,214,77,232,102,15,214,85,
+  224,102,15,214,93,216,255,73,188,237,237,255,73,199,192,237,72,199,194,237,
+  76,137,225,232,251,1,0,255,73,199,192,237,72,199,194,252,255,252,255,252,
+  255,252,255,76,137,225,232,251,1,0,255,73,199,192,237,72,199,194,237,76,137,
+  225,232,251,1,0,73,184,237,237,72,199,194,252,255,252,255,252,255,252,255,
+  76,137,225,232,251,1,1,255,72,137,8,72,199,194,252,254,252,255,252,255,252,
+  255,76,137,225,232,251,1,2,255,73,184,237,237,72,199,194,0,0,0,0,76,137,225,
+  232,251,1,1,255,72,137,8,255,102,15,214,0,255,217,24,255,217,88,4,255,102,
+  15,214,64,8,255,252,243,15,126,200,76,137,225,232,251,1,3,255,15,182,201,
+  72,137,202,76,137,225,232,251,1,4,255,15,182,201,255,15,190,201,255,72,137,
+  202,76,137,225,232,251,1,5,255,15,183,201,255,15,191,201,255,72,137,202,76,
+  137,225,232,251,1,6,255,73,185,237,237,73,199,192,237,72,199,194,237,76,137,
+  225,232,251,1,7,255,73,199,192,237,72,199,194,252,254,252,255,252,255,252,
+  255,76,137,225,232,251,1,0,73,185,237,237,73,199,192,252,255,252,255,252,
+  255,252,255,72,199,194,252,254,252,255,252,255,252,255,76,137,225,232,251,
+  1,8,72,137,68,36,32,72,199,194,252,252,252,255,252,255,252,255,76,137,225,
+  232,251,1,9,72,139,68,36,32,255,73,199,192,237,72,199,194,252,254,252,255,
+  252,255,252,255,76,137,225,232,251,1,0,73,185,237,237,73,199,192,252,255,
+  252,255,252,255,252,255,72,199,194,252,254,252,255,252,255,252,255,76,137,
+  225,232,251,1,10,137,68,36,32,72,199,194,252,252,252,255,252,255,252,255,
+  76,137,225,232,251,1,9,139,68,36,32,255,72,199,194,252,254,252,255,252,255,
+  252,255,76,137,225,232,251,1,9,255,72,199,194,252,255,252,255,252,255,252,
+  255,76,137,225,232,251,1,11,255,72,199,194,252,255,252,255,252,255,252,255,
+  76,137,225,232,251,1,12,255,137,68,36,32,72,199,194,252,253,252,255,252,255,
+  252,255,76,137,225,232,251,1,9,139,68,36,32,255,72,199,194,252,255,252,255,
+  252,255,252,255,76,137,225,232,251,1,13,255,72,199,194,252,255,252,255,252,
+  255,252,255,76,137,225,232,251,1,14,255,72,137,68,36,32,72,199,194,252,253,
+  252,255,252,255,252,255,76,137,225,232,251,1,9,72,139,68,36,32,255,72,199,
+  194,252,255,252,255,252,255,252,255,76,137,225,232,251,1,15,72,137,68,36,
+  32,72,199,194,252,253,252,255,252,255,252,255,76,137,225,232,251,1,9,72,139,
+  68,36,32,255,72,199,194,252,255,252,255,252,255,252,255,76,137,225,232,251,
+  1,16,102,15,214,68,36,32,72,199,194,252,253,252,255,252,255,252,255,76,137,
+  225,232,251,1,9,255,252,242,15,90,68,36,32,255,252,243,15,126,68,36,32,255,
+  72,199,194,252,255,252,255,252,255,252,255,76,137,225,232,251,1,17,102,15,
+  214,68,36,32,72,199,194,252,253,252,255,252,255,252,255,76,137,225,232,251,
+  1,9,252,243,15,126,68,36,32,255,72,199,194,252,255,252,255,252,255,252,255,
+  76,137,225,232,251,1,18,102,15,214,68,36,32,102,15,214,76,36,40,72,199,194,
+  252,253,252,255,252,255,252,255,76,137,225,232,251,1,9,252,243,15,126,68,
+  36,32,252,243,15,126,76,36,40,255,72,139,141,233,73,199,192,252,255,252,255,
+  252,255,252,255,76,137,226,72,137,201,232,251,1,18,72,131,252,236,4,72,199,
+  194,252,253,252,255,252,255,252,255,76,137,225,232,251,1,9,255,76,139,101,
+  252,248,72,137,252,236,93,194,236,255,85,72,137,229,65,84,65,85,73,137,204,
+  72,131,252,236,32,76,137,225,232,251,1,19,73,137,197,72,129,252,248,239,255,
+  15,141,244,248,102,184,0,0,72,186,237,237,76,137,225,232,251,1,20,248,2,15,
+  142,244,247,102,184,0,0,72,186,237,237,76,137,225,232,251,1,20,255,15,141,
+  244,247,102,184,0,0,72,186,237,237,76,137,225,232,251,1,20,255,248,1,255,
+  72,193,224,4,72,41,196,72,129,252,236,239,255,73,184,237,237,72,199,194,0,
+  0,0,0,76,137,225,232,251,1,1,72,131,252,236,16,255,73,185,237,237,73,199,
+  192,237,72,199,194,237,76,137,225,232,251,1,8,255,73,185,237,237,73,199,192,
+  237,72,199,194,237,76,137,225,232,251,1,21,255,73,185,237,237,73,199,192,
+  237,72,199,194,237,76,137,225,232,251,1,10,255,72,199,194,237,76,137,225,
+  232,251,1,12,255,15,182,192,255,15,190,192,255,15,183,192,255,15,191,192,
+  255,72,199,194,237,76,137,225,232,251,1,12,131,252,248,0,15,149,208,15,182,
+  192,255,72,199,194,237,76,137,225,232,251,1,11,255,72,199,194,237,76,137,
+  225,232,251,1,15,255,72,199,194,237,76,137,225,232,251,1,13,255,72,199,194,
+  237,76,137,225,232,251,1,14,255,72,199,194,237,76,137,225,232,251,1,16,255,
+  72,199,194,237,76,137,225,232,251,1,18,255,252,243,15,126,193,255,72,141,
+  132,253,36,233,72,131,252,236,4,73,199,192,237,76,137,226,72,137,193,232,
+  251,1,18,255,72,199,194,237,76,137,225,232,251,1,17,255,72,199,194,237,76,
+  137,225,232,251,1,17,137,4,36,217,4,36,255,137,20,36,217,4,36,255,73,129,
+  252,253,239,15,142,244,247,72,137,224,72,129,192,239,73,137,193,77,137,232,
+  72,199,194,237,76,137,225,232,251,1,22,72,137,224,72,129,192,239,73,137,193,
+  73,199,192,237,72,199,194,237,76,137,225,232,251,1,23,252,233,244,248,248,
+  1,72,137,224,72,129,192,239,73,137,193,77,137,232,72,199,194,237,76,137,225,
+  232,251,1,23,248,2,255,72,137,224,72,129,192,239,73,137,193,77,137,232,72,
+  199,194,237,76,137,225,232,251,1,22,255,72,185,237,237,139,1,72,137,193,232,
+  251,1,24,255,72,131,196,32,255,252,243,15,126,156,253,36,233,255,76,139,140,
+  253,36,233,255,252,243,15,126,148,253,36,233,255,76,139,132,253,36,233,255,
+  252,243,15,126,140,253,36,233,255,72,139,148,253,36,233,255,252,243,15,126,
+  4,36,255,72,139,12,36,255,232,251,1,25,72,131,252,236,48,255,72,137,68,36,
+  32,232,251,1,26,72,185,237,237,137,1,73,184,237,237,72,199,194,237,76,137,
+  225,232,251,1,1,72,139,76,36,32,72,137,8,184,1,0,0,0,76,139,109,252,240,76,
+  139,101,252,248,72,137,252,236,93,195,255,72,137,68,36,32,232,251,1,26,72,
+  185,237,237,137,1,72,139,68,36,32,72,137,194,76,137,225,232,251,1,27,184,
+  1,0,0,0,76,139,109,252,240,76,139,101,252,248,72,137,252,236,93,195,255,72,
+  137,68,36,32,232,251,1,26,72,185,237,237,137,1,73,184,237,237,72,199,194,
+  0,0,0,0,76,137,225,232,251,1,1,72,139,76,36,32,72,137,8,184,1,0,0,0,76,139,
+  109,252,240,76,139,101,252,248,72,137,252,236,93,195,255,102,15,214,68,36,
+  32,232,251,1,26,72,185,237,237,137,1,73,184,237,237,72,199,194,237,76,137,
+  225,232,251,1,1,72,139,76,36,32,72,137,8,184,1,0,0,0,76,139,109,252,240,76,
+  139,101,252,248,72,137,252,236,93,195,255,102,15,214,76,36,40,102,15,214,
+  68,36,32,232,251,1,26,72,185,237,237,137,1,73,184,237,237,72,199,194,237,
+  76,137,225,232,251,1,1,72,139,76,36,40,72,137,72,8,72,139,76,36,32,72,137,
+  8,184,1,0,0,0,76,139,109,252,240,76,139,101,252,248,72,137,252,236,93,195,
+  255,232,251,1,26,72,185,237,237,137,1,184,0,0,0,0,76,139,109,252,240,76,139,
+  101,252,248,72,137,252,236,93,195,255,15,182,192,137,68,36,32,232,251,1,26,
+  72,185,237,237,137,1,139,68,36,32,72,137,194,76,137,225,232,251,1,4,184,1,
+  0,0,0,76,139,109,252,240,76,139,101,252,248,72,137,252,236,93,195,255,137,
+  68,36,32,232,251,1,26,72,185,237,237,137,1,139,68,36,32,72,137,194,76,137,
+  225,232,251,1,5,184,1,0,0,0,76,139,109,252,240,76,139,101,252,248,72,137,
+  252,236,93,195,255,137,68,36,32,232,251,1,26,72,185,237,237,137,1,139,68,
+  36,32,72,137,194,76,137,225,232,251,1,6,184,1,0,0,0,76,139,109,252,240,76,
+  139,101,252,248,72,137,252,236,93,195,255,252,243,15,90,192,102,15,214,68,
+  36,32,232,251,1,26,72,185,237,237,137,1,252,243,15,126,76,36,32,76,137,225,
+  232,251,1,3,184,1,0,0,0,76,139,109,252,240,76,139,101,252,248,72,137,252,
+  236,93,195,255
 };
 
 static const char *const globnames[] = {
-  "lua_return_arg",
-  "lua_return_void",
-  "lua_return_double",
-  "lua_return_bool",
-  "lua_return_int",
-  "lua_return_uint",
-  "lua_return_long",
-  "lua_return_ulong",
-  "too_few_arguments",
-  "too_many_arguments",
-  "save_registers",
   (const char *)0
 };
 static const char *const extnames[] = {
-  "GetLastError",
+  "lua_rawgeti",
+  "push_cdata",
+  "lua_remove",
   "lua_pushnumber",
   "lua_pushboolean",
   "push_int",
   "push_uint",
-  "lua_pushinteger",
-  "luaL_error",
-  "lua_rawgeti",
-  "push_cdata",
-  "lua_remove",
   "lua_callk",
   "check_typed_pointer",
   "lua_settop",
@@ -164,13 +146,30 @@ static const char *const extnames[] = {
   "check_complex_float",
   "check_complex_double",
   "lua_gettop",
+  "luaL_error",
   "check_typed_cfunction",
   "unpack_varargs_stack",
   "unpack_varargs_reg",
   "SetLastError",
   "FUNCTION",
+  "GetLastError",
+  "lua_pushinteger",
   (const char *)0
 };
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -224,42 +223,6 @@ void compile_globals(struct jit* jit, lua_State* L)
     /* Note the various call_* functions want 32 bytes of 16 byte aligned
      * stack
      */
-
-
-
-
-    /* the general idea for the return functions is:
-     * 1) Save return value on stack
-     * 2) Call get_errno (this trashes the registers hence #1)
-     * 3) Unpack return value from stack
-     * 4) Call lua push function
-     * 5) Set eax to number of returned args (0 or 1)
-     * 6) Call return which pops our stack frame
-     */
-
-    dasm_put(Dst, 0);
-
-    dasm_put(Dst, 24, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
-
-    dasm_put(Dst, 58, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
-
-    dasm_put(Dst, 95, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
-
-    dasm_put(Dst, 133, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
-
-    dasm_put(Dst, 168, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
-
-#if LUA_VERSION_NUM == 503
-    dasm_put(Dst, 203, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
-
-    dasm_put(Dst, 240, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
-#endif
-
-    dasm_put(Dst, 277, (unsigned int)((uintptr_t)(&"too few arguments")), (unsigned int)(((uintptr_t)(&"too few arguments"))>>32));
-
-    dasm_put(Dst, 295, (unsigned int)((uintptr_t)(&"too many arguments")), (unsigned int)(((uintptr_t)(&"too many arguments"))>>32));
-
-    dasm_put(Dst, 313);
 
     compile(Dst, L, NULL, LUA_NOREF);
 }
@@ -369,25 +332,25 @@ static void get_int(Dst_DECL, const struct ctype* ct, struct reg_alloc* reg, int
     /* grab the register from the shadow space */
 #ifdef _WIN64
     if (reg->regs < MAX_REGISTERS(ct)) {
-        dasm_put(Dst, 354, 16 + 8*reg->regs);
+        dasm_put(Dst, 0, 16 + 8*reg->regs);
         reg->regs++;
     }
 #elif __amd64__
     if (reg->ints < MAX_INT_REGISTERS(ct)) {
-        dasm_put(Dst, 354, - 80 - 8*reg->ints);
+        dasm_put(Dst, 0, - 80 - 8*reg->ints);
         reg->ints++;
     }
 #else
     if (!is_int64 && reg->ints < MAX_INT_REGISTERS(ct)) {
-        dasm_put(Dst, 355, - 8 - 4*reg->ints);
+        dasm_put(Dst, 1, - 8 - 4*reg->ints);
         reg->ints++;
     }
 #endif
     else if (is_int64) {
-        dasm_put(Dst, 354, reg->off);
+        dasm_put(Dst, 0, reg->off);
         reg->off += 8;
     } else {
-        dasm_put(Dst, 355, reg->off);
+        dasm_put(Dst, 1, reg->off);
         reg->off += 4;
     }
 }
@@ -396,17 +359,17 @@ static void add_int(Dst_DECL, const struct ctype* ct, struct reg_alloc* reg, int
 {
 #ifdef _WIN64
     if (reg->regs < MAX_REGISTERS(ct)) {
-        dasm_put(Dst, 359, 32 + 8*(reg->regs));
+        dasm_put(Dst, 5, 32 + 8*(reg->regs));
         reg->is_int[reg->regs++] = 1;
     }
 #elif __amd64__
     if (reg->ints < MAX_INT_REGISTERS(ct)) {
-        dasm_put(Dst, 359, 32 + 8*reg->ints);
+        dasm_put(Dst, 5, 32 + 8*reg->ints);
         reg->ints++;
     }
 #else
     if (!is_int64 && reg->ints < MAX_INT_REGISTERS(ct)) {
-        dasm_put(Dst, 359, 32 + 4*reg->ints);
+        dasm_put(Dst, 5, 32 + 4*reg->ints);
         reg->ints++;
     }
 #endif
@@ -417,10 +380,10 @@ static void add_int(Dst_DECL, const struct ctype* ct, struct reg_alloc* reg, int
         }
 #endif
         if (is_int64) {
-            dasm_put(Dst, 359, reg->off);
+            dasm_put(Dst, 5, reg->off);
             reg->off += 8;
         } else {
-            dasm_put(Dst, 360, reg->off);
+            dasm_put(Dst, 6, reg->off);
             reg->off += 4;
         }
     }
@@ -431,10 +394,10 @@ static void get_float(Dst_DECL, const struct ctype* ct, struct reg_alloc* reg, i
 #if !defined _WIN64 && !defined __amd64__
     assert(MAX_FLOAT_REGISTERS(ct) == 0);
     if (is_double) {
-        dasm_put(Dst, 366, reg->off);
+        dasm_put(Dst, 12, reg->off);
         reg->off += 8;
     } else {
-        dasm_put(Dst, 370, reg->off);
+        dasm_put(Dst, 16, reg->off);
         reg->off += 4;
     }
 #else
@@ -457,9 +420,9 @@ static void get_float(Dst_DECL, const struct ctype* ct, struct reg_alloc* reg, i
     }
 
     if (is_double) {
-        dasm_put(Dst, 374, off);
+        dasm_put(Dst, 20, off);
     } else {
-        dasm_put(Dst, 381, off);
+        dasm_put(Dst, 27, off);
     }
 #endif
 }
@@ -469,10 +432,10 @@ static void add_float(Dst_DECL, const struct ctype* ct, struct reg_alloc* reg, i
 #if !defined _WIN64 && !defined __amd64__
     assert(MAX_FLOAT_REGISTERS(ct) == 0);
     if (is_double) {
-        dasm_put(Dst, 388, reg->off);
+        dasm_put(Dst, 34, reg->off);
         reg->off += 8;
     } else {
-        dasm_put(Dst, 394, reg->off);
+        dasm_put(Dst, 40, reg->off);
         reg->off += 4;
     }
 #else
@@ -480,28 +443,28 @@ static void add_float(Dst_DECL, const struct ctype* ct, struct reg_alloc* reg, i
 #ifdef _WIN64
     if (reg->regs < MAX_REGISTERS(ct)) {
         if (is_double) {
-            dasm_put(Dst, 400, 32 + 8*(reg->regs));
+            dasm_put(Dst, 46, 32 + 8*(reg->regs));
         } else {
-            dasm_put(Dst, 408, 32 + 8*(reg->regs));
+            dasm_put(Dst, 54, 32 + 8*(reg->regs));
         }
         reg->is_float[reg->regs++] = 1;
     }
 #else
     if (reg->floats < MAX_FLOAT_REGISTERS(ct)) {
         if (is_double) {
-            dasm_put(Dst, 400, 32 + 8*(MAX_INT_REGISTERS(ct) + reg->floats));
+            dasm_put(Dst, 46, 32 + 8*(MAX_INT_REGISTERS(ct) + reg->floats));
         } else {
-            dasm_put(Dst, 408, 32 + 8*(MAX_INT_REGISTERS(ct) + reg->floats));
+            dasm_put(Dst, 54, 32 + 8*(MAX_INT_REGISTERS(ct) + reg->floats));
         }
         reg->floats++;
     }
 #endif
 
     else if (is_double) {
-        dasm_put(Dst, 400, reg->off);
+        dasm_put(Dst, 46, reg->off);
         reg->off += 8;
     } else {
-        dasm_put(Dst, 421, reg->off);
+        dasm_put(Dst, 67, reg->off);
         reg->off += 4;
     }
 #endif
@@ -557,21 +520,21 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
 
     // setup a stack frame to hold args for the call into lua_call
 
-    dasm_put(Dst, 434, 8 + 16 + 32 + REGISTER_STACK_SPACE(ct));
+    dasm_put(Dst, 80, 8 + 16 + 32 + REGISTER_STACK_SPACE(ct));
     if (ct->calling_convention == FAST_CALL) {
     }
 
     // hardcode the lua_State* value into the assembly
-    dasm_put(Dst, 449, (unsigned int)((uintptr_t)(L)), (unsigned int)(((uintptr_t)(L))>>32));
+    dasm_put(Dst, 129, (unsigned int)((uintptr_t)(L)), (unsigned int)(((uintptr_t)(L))>>32));
 
     /* get the upval table */
-    dasm_put(Dst, 454, ref, LUA_REGISTRYINDEX);
+    dasm_put(Dst, 134, ref, LUA_REGISTRYINDEX);
 
     /* get the lua function */
     lua_pushvalue(L, fidx);
     lua_rawseti(L, -2, ++num_upvals);
     assert(num_upvals == CALLBACK_FUNC_USR_IDX);
-    dasm_put(Dst, 470, num_upvals);
+    dasm_put(Dst, 150, num_upvals);
 
 #if !defined _WIN64 && !defined __amd64__
     lua_rawgeti(L, ct_usr, 0);
@@ -596,90 +559,90 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
             /* on the lua stack in the callback:
              * upval tbl, lua func, i-1 args
              */
-            dasm_put(Dst, 493, num_upvals-1, -i-1, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
+            dasm_put(Dst, 173, num_upvals-1, -i-1, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
             get_pointer(Dst, ct, &reg);
-            dasm_put(Dst, 531);
+            dasm_put(Dst, 211);
         } else {
             switch (mt->type) {
             case INT64_TYPE:
                 lua_getuservalue(L, -1);
                 lua_rawseti(L, -3, ++num_upvals); /* mt */
                 lua_pop(L, 1);
-                dasm_put(Dst, 553, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
+                dasm_put(Dst, 233, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
                 get_int(Dst, ct, &reg, 1);
-                dasm_put(Dst, 572);
+                dasm_put(Dst, 252);
                 break;
 
             case INTPTR_TYPE:
                 lua_getuservalue(L, -1);
                 lua_rawseti(L, -3, ++num_upvals); /* mt */
                 lua_pop(L, 1);
-                dasm_put(Dst, 553, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
+                dasm_put(Dst, 233, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
                 get_pointer(Dst, ct, &reg);
-                dasm_put(Dst, 572);
+                dasm_put(Dst, 252);
                 break;
 
             case COMPLEX_FLOAT_TYPE:
                 lua_pop(L, 1);
 #if defined _WIN64 || defined __amd64__
                 /* complex floats are two floats packed into a double */
-                dasm_put(Dst, 553, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
+                dasm_put(Dst, 233, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
                 get_float(Dst, ct, &reg, 1);
-                dasm_put(Dst, 576);
+                dasm_put(Dst, 256);
 #else
                 /* complex floats are real followed by imag on the stack */
-                dasm_put(Dst, 553, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
+                dasm_put(Dst, 233, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
                 get_float(Dst, ct, &reg, 0);
-                dasm_put(Dst, 581);
+                dasm_put(Dst, 261);
                 get_float(Dst, ct, &reg, 0);
-                dasm_put(Dst, 584);
+                dasm_put(Dst, 264);
 #endif
                 break;
 
             case COMPLEX_DOUBLE_TYPE:
                 lua_pop(L, 1);
-                dasm_put(Dst, 553, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
+                dasm_put(Dst, 233, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
                 /* real */
                 get_float(Dst, ct, &reg, 1);
-                dasm_put(Dst, 576);
+                dasm_put(Dst, 256);
                 /* imag */
                 get_float(Dst, ct, &reg, 1);
-                dasm_put(Dst, 588);
+                dasm_put(Dst, 268);
                 break;
 
             case FLOAT_TYPE:
             case DOUBLE_TYPE:
                 lua_pop(L, 1);
                 get_float(Dst, ct, &reg, mt->type == DOUBLE_TYPE);
-                dasm_put(Dst, 594);
+                dasm_put(Dst, 274);
                 break;
 
             case BOOL_TYPE:
                 lua_pop(L, 1);
                 get_int(Dst, ct, &reg, 0);
-                dasm_put(Dst, 607);
+                dasm_put(Dst, 287);
                 break;
 
             case INT8_TYPE:
                 lua_pop(L, 1);
                 get_int(Dst, ct, &reg, 0);
                 if (mt->is_unsigned) {
-                    dasm_put(Dst, 621);
+                    dasm_put(Dst, 301);
                 } else {
-                    dasm_put(Dst, 625);
+                    dasm_put(Dst, 305);
                 }
-                dasm_put(Dst, 629);
+                dasm_put(Dst, 309);
                 break;
 
             case INT16_TYPE:
                 lua_pop(L, 1);
                 get_int(Dst, ct, &reg, 0);
                 if (mt->is_unsigned) {
-                    dasm_put(Dst, 640);
+                    dasm_put(Dst, 320);
                 } else {
-                    dasm_put(Dst, 644);
+                    dasm_put(Dst, 324);
                 }
-                dasm_put(Dst, 629);
+                dasm_put(Dst, 309);
                 break;
 
             case ENUM_TYPE:
@@ -687,9 +650,9 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
                 lua_pop(L, 1);
                 get_int(Dst, ct, &reg, 0);
                 if (mt->is_unsigned) {
-                    dasm_put(Dst, 648);
+                    dasm_put(Dst, 328);
                 } else {
-                    dasm_put(Dst, 629);
+                    dasm_put(Dst, 309);
                 }
                 break;
 
@@ -702,7 +665,7 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
     lua_rawgeti(L, ct_usr, 0);
     mt = (const struct ctype*) lua_touserdata(L, -1);
 
-    dasm_put(Dst, 659, (unsigned int)((uintptr_t)(0)), (unsigned int)(((uintptr_t)(0))>>32), (mt->pointers || mt->is_reference || mt->type != VOID_TYPE) ? 1 : 0, nargs);
+    dasm_put(Dst, 339, (unsigned int)((uintptr_t)(0)), (unsigned int)(((uintptr_t)(0))>>32), (mt->pointers || mt->is_reference || mt->type != VOID_TYPE) ? 1 : 0, nargs);
 
     // Unpack the return argument if not "void", also clean-up the lua stack
     // to remove the return argument and bind table. Use lua_settop rather
@@ -711,7 +674,7 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
         lua_getuservalue(L, -1);
         lua_rawseti(L, -3, ++num_upvals); /* usr value */
         lua_rawseti(L, -2, ++num_upvals); /* mt */
-        dasm_put(Dst, 679, num_upvals-1, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
+        dasm_put(Dst, 359, num_upvals-1, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
 
     } else {
         switch (mt->type) {
@@ -719,12 +682,12 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
             lua_getuservalue(L, -1);
             lua_rawseti(L, -3, ++num_upvals); /* usr value */
             lua_rawseti(L, -2, ++num_upvals); /* mt */
-            dasm_put(Dst, 763, num_upvals-1, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
+            dasm_put(Dst, 443, num_upvals-1, (unsigned int)((uintptr_t)(mt)), (unsigned int)(((uintptr_t)(mt))>>32));
             break;
 
         case VOID_TYPE:
             lua_pop(L, 1);
-            dasm_put(Dst, 845);
+            dasm_put(Dst, 525);
             break;
 
         case BOOL_TYPE:
@@ -733,38 +696,38 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
         case INT32_TYPE:
             lua_pop(L, 1);
             if (mt->is_unsigned) {
-                dasm_put(Dst, 864);
+                dasm_put(Dst, 544);
             } else {
-                dasm_put(Dst, 883);
+                dasm_put(Dst, 563);
             }
-            dasm_put(Dst, 902);
+            dasm_put(Dst, 582);
             break;
 
         case INT64_TYPE:
             lua_pop(L, 1);
 
             if (mt->is_unsigned) {
-                dasm_put(Dst, 929);
+                dasm_put(Dst, 609);
             } else {
-                dasm_put(Dst, 948);
+                dasm_put(Dst, 628);
             }
 
-            dasm_put(Dst, 967);
+            dasm_put(Dst, 647);
             break;
 
         case INTPTR_TYPE:
             lua_pop(L, 1);
-            dasm_put(Dst, 996);
+            dasm_put(Dst, 676);
             break;
 
         case FLOAT_TYPE:
         case DOUBLE_TYPE:
             lua_pop(L, 1);
-            dasm_put(Dst, 1043);
+            dasm_put(Dst, 723);
             if (mt->type == FLOAT_TYPE) {
-                dasm_put(Dst, 1086);
+                dasm_put(Dst, 766);
             } else {
-                dasm_put(Dst, 1094);
+                dasm_put(Dst, 774);
             }
             break;
 
@@ -775,7 +738,7 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
 #endif
             /* on 64 bit complex floats are two floats packed into a double,
              * on 32 bit returned complex floats use eax and edx */
-            dasm_put(Dst, 1102);
+            dasm_put(Dst, 782);
             break;
 
         case COMPLEX_DOUBLE_TYPE:
@@ -788,9 +751,9 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
              * the returned arg is stored which is popped by the called
              * function */
 #if defined _WIN64 || defined __amd64__
-            dasm_put(Dst, 1152);
+            dasm_put(Dst, 832);
 #else
-            dasm_put(Dst, 1215, hidden_arg_off);
+            dasm_put(Dst, 895, hidden_arg_off);
 #endif
             break;
 
@@ -799,7 +762,7 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
         }
     }
 
-    dasm_put(Dst, 1264, x86_return_size(L, ct_usr, ct));
+    dasm_put(Dst, 944, x86_return_size(L, ct_usr, ct));
 
     lua_pop(L, 1); /* upval table - already in registry */
     assert(lua_gettop(L) == top);
@@ -841,15 +804,18 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
         luaL_error(L, "vararg is only allowed with the c calling convention");
     }
 
-    dasm_put(Dst, 1277, nargs);
-
+    dasm_put(Dst, 957, nargs);
     if (!ct->has_var_arg) {
-        dasm_put(Dst, 1313);
+        dasm_put(Dst, 989, (unsigned int)((uintptr_t)(&"too few arguments")), (unsigned int)(((uintptr_t)(&"too few arguments"))>>32), (unsigned int)((uintptr_t)(&"too many arguments")), (unsigned int)(((uintptr_t)(&"too many arguments"))>>32));
+    } else {
+        dasm_put(Dst, 1030, (unsigned int)((uintptr_t)(&"too few arguments")), (unsigned int)(((uintptr_t)(&"too few arguments"))>>32));
     }
+
+    dasm_put(Dst, 1050);
 
     /* no need to zero extend eax returned by lua_gettop to rax as x86-64
      * preguarentees that the upper 32 bits will be zero */
-    dasm_put(Dst, 1318, 32 + REGISTER_STACK_SPACE(ct));
+    dasm_put(Dst, 1053, 32 + REGISTER_STACK_SPACE(ct));
 
 #if !defined _WIN64 && !defined __amd64__
     /* Returned complex doubles require a hidden first parameter where the
@@ -860,7 +826,7 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
         /* we can allocate more space for arguments as long as no add_*
          * function has been called yet, mbr_ct will be added as an upvalue in
          * the return processing later */
-        dasm_put(Dst, 1331, (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32));
+        dasm_put(Dst, 1066, (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32));
         add_pointer(Dst, ct, &reg);
     }
     lua_pop(L, 1);
@@ -873,80 +839,80 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
         if (mbr_ct->pointers || mbr_ct->is_reference) {
             lua_getuservalue(L, -1);
             num_upvals += 2;
-            dasm_put(Dst, 1355, (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals), i);
+            dasm_put(Dst, 1090, (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals), i);
             add_pointer(Dst, ct, &reg);
         } else {
             switch (mbr_ct->type) {
             case FUNCTION_PTR_TYPE:
                 lua_getuservalue(L, -1);
                 num_upvals += 2;
-                dasm_put(Dst, 1375, (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals), i);
+                dasm_put(Dst, 1110, (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals), i);
                 add_pointer(Dst, ct, &reg);
                 break;
 
             case ENUM_TYPE:
                 lua_getuservalue(L, -1);
                 num_upvals += 2;
-                dasm_put(Dst, 1395, (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals), i);
+                dasm_put(Dst, 1130, (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals), i);
                 add_int(Dst, ct, &reg, 0);
                 break;
 
             case INT8_TYPE:
-                dasm_put(Dst, 1415, i);
+                dasm_put(Dst, 1150, i);
                 if (mbr_ct->is_unsigned) {
-                    dasm_put(Dst, 1427);
+                    dasm_put(Dst, 1162);
                 } else {
-                    dasm_put(Dst, 1431);
+                    dasm_put(Dst, 1166);
                 }
                 add_int(Dst, ct, &reg, 0);
                 lua_pop(L, 1);
                 break;
 
             case INT16_TYPE:
-                dasm_put(Dst, 1415, i);
+                dasm_put(Dst, 1150, i);
                 if (mbr_ct->is_unsigned) {
-                    dasm_put(Dst, 1435);
+                    dasm_put(Dst, 1170);
                 } else {
-                    dasm_put(Dst, 1439);
+                    dasm_put(Dst, 1174);
                 }
                 add_int(Dst, ct, &reg, 0);
                 lua_pop(L, 1);
                 break;
 
             case BOOL_TYPE:
-                dasm_put(Dst, 1443, i);
+                dasm_put(Dst, 1178, i);
                 add_int(Dst, ct, &reg, 0);
                 lua_pop(L, 1);
                 break;
 
             case INT32_TYPE:
                 if (mbr_ct->is_unsigned) {
-                    dasm_put(Dst, 1465, i);
+                    dasm_put(Dst, 1200, i);
                 } else {
-                    dasm_put(Dst, 1415, i);
+                    dasm_put(Dst, 1150, i);
                 }
                 add_int(Dst, ct, &reg, 0);
                 lua_pop(L, 1);
                 break;
 
             case INTPTR_TYPE:
-                dasm_put(Dst, 1477, i);
+                dasm_put(Dst, 1212, i);
                 add_pointer(Dst, ct, &reg);
                 lua_pop(L, 1);
                 break;
 
             case INT64_TYPE:
                 if (mbr_ct->is_unsigned) {
-                    dasm_put(Dst, 1489, i);
+                    dasm_put(Dst, 1224, i);
                 } else {
-                    dasm_put(Dst, 1501, i);
+                    dasm_put(Dst, 1236, i);
                 }
                 add_int(Dst, ct, &reg, 1);
                 lua_pop(L, 1);
                 break;
 
             case DOUBLE_TYPE:
-                dasm_put(Dst, 1513, i);
+                dasm_put(Dst, 1248, i);
                 add_float(Dst, ct, &reg, 1);
                 lua_pop(L, 1);
                 break;
@@ -957,33 +923,33 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
                  * the returned arg is stored (this is popped by the called
                  * function) */
 #if defined _WIN64 || defined __amd64__
-                dasm_put(Dst, 1525, i);
+                dasm_put(Dst, 1260, i);
                 add_float(Dst, ct, &reg, 1);
-                dasm_put(Dst, 1537);
+                dasm_put(Dst, 1272);
                 add_float(Dst, ct, &reg, 1);
 #else
-                dasm_put(Dst, 1543, reg.off, i);
+                dasm_put(Dst, 1278, reg.off, i);
                 reg.off += 16;
 #endif
                 lua_pop(L, 1);
                 break;
 
             case FLOAT_TYPE:
-                dasm_put(Dst, 1513, i);
+                dasm_put(Dst, 1248, i);
                 add_float(Dst, ct, &reg, 0);
                 lua_pop(L, 1);
                 break;
 
             case COMPLEX_FLOAT_TYPE:
 #if defined _WIN64 || defined __amd64__
-                dasm_put(Dst, 1569, i);
+                dasm_put(Dst, 1304, i);
                 /* complex floats are two floats packed into a double */
                 add_float(Dst, ct, &reg, 1);
 #else
                 /* returned complex floats use eax and edx */
-                dasm_put(Dst, 1581, i);
+                dasm_put(Dst, 1316, i);
                 add_float(Dst, ct, &reg, 0);
-                dasm_put(Dst, 1599);
+                dasm_put(Dst, 1334);
                 add_float(Dst, ct, &reg, 0);
 #endif
                 lua_pop(L, 1);
@@ -999,9 +965,9 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
 #ifdef _WIN64
         if (reg.regs < MAX_REGISTERS(ct)) {
             assert(reg.regs == nargs);
-            dasm_put(Dst, 1606, MAX_REGISTERS(ct), 32 + 8*MAX_REGISTERS(ct), MAX_REGISTERS(ct)+1, 32 + 8*(reg.regs), MAX_REGISTERS(ct), nargs+1, 32 + 8*(reg.regs), nargs+1);
+            dasm_put(Dst, 1341, MAX_REGISTERS(ct), 32 + 8*MAX_REGISTERS(ct), MAX_REGISTERS(ct)+1, 32 + 8*(reg.regs), MAX_REGISTERS(ct), nargs+1, 32 + 8*(reg.regs), nargs+1);
         } else {
-            dasm_put(Dst, 1697, reg.off, nargs+1);
+            dasm_put(Dst, 1432, reg.off, nargs+1);
         }
 
         for (i = nargs; i < MAX_REGISTERS(ct); i++) {
@@ -1022,40 +988,40 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
 #endif
     }
 
-    dasm_put(Dst, 1722, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
+    dasm_put(Dst, 1457, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
 
     /* remove the stack space to call local functions */
-    dasm_put(Dst, 1736);
+    dasm_put(Dst, 1471);
 
 #ifdef _WIN64
     switch (reg.regs) {
     case 4:
         if (reg.is_float[3]) {
-            dasm_put(Dst, 1741, 8*3);
+            dasm_put(Dst, 1476, 8*3);
         }
         if (reg.is_int[3]) {
-            dasm_put(Dst, 1750, 8*3);
+            dasm_put(Dst, 1485, 8*3);
         }
     case 3:
         if (reg.is_float[2]) {
-            dasm_put(Dst, 1757, 8*2);
+            dasm_put(Dst, 1492, 8*2);
         }
         if (reg.is_int[2]) {
-            dasm_put(Dst, 1766, 8*2);
+            dasm_put(Dst, 1501, 8*2);
         }
     case 2:
         if (reg.is_float[1]) {
-            dasm_put(Dst, 1773, 8*1);
+            dasm_put(Dst, 1508, 8*1);
         }
         if (reg.is_int[1]) {
-            dasm_put(Dst, 1782, 8*1);
+            dasm_put(Dst, 1517, 8*1);
         }
     case 1:
         if (reg.is_float[0]) {
-            dasm_put(Dst, 1789);
+            dasm_put(Dst, 1524);
         }
         if (reg.is_int[0]) {
-            dasm_put(Dst, 1796);
+            dasm_put(Dst, 1531);
         }
     case 0:
         break;
@@ -1109,7 +1075,7 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
     }
 #endif
 
-    dasm_put(Dst, 1801);
+    dasm_put(Dst, 1536);
 
     /* note on windows X86 the stack may be only aligned to 4 (stdcall will
      * have popped a multiple of 4 bytes), but we don't need 16 byte alignment on
@@ -1122,90 +1088,90 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
     if (mbr_ct->pointers || mbr_ct->is_reference || mbr_ct->type == INTPTR_TYPE) {
         lua_getuservalue(L, -1);
         num_upvals += 2;
-        dasm_put(Dst, 1811, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32), (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals));
+        dasm_put(Dst, 1546, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32), (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals));
 
     } else {
         switch (mbr_ct->type) {
         case FUNCTION_PTR_TYPE:
             lua_getuservalue(L, -1);
             num_upvals += 2;
-            dasm_put(Dst, 1811, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32), (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals));
+            dasm_put(Dst, 1546, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32), (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals));
             break;
 
         case INT64_TYPE:
 #if LUA_VERSION_NUM == 503
             lua_pop(L, 1);
             if (mbr_ct->is_unsigned) {
-                dasm_put(Dst, 1854);
+                dasm_put(Dst, 1606, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
             } else {
-                dasm_put(Dst, 1859);
+                dasm_put(Dst, 1606, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
             }
 #else
             num_upvals++;
-            dasm_put(Dst, 1864, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32), (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32));
+            dasm_put(Dst, 1658, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32), (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32));
 #endif
             break;
 
         case COMPLEX_FLOAT_TYPE:
             lua_getuservalue(L, -1);
             num_upvals += 2;
-            dasm_put(Dst, 1910, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32), (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals));
+            dasm_put(Dst, 1721, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32), (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals));
             break;
 
         case COMPLEX_DOUBLE_TYPE:
             lua_getuservalue(L, -1);
             num_upvals += 2;
-            dasm_put(Dst, 1954, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32), (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals));
+            dasm_put(Dst, 1782, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32), (unsigned int)((uintptr_t)(mbr_ct)), (unsigned int)(((uintptr_t)(mbr_ct))>>32), lua_upvalueindex(num_upvals));
             break;
 
         case VOID_TYPE:
             lua_pop(L, 1);
-            dasm_put(Dst, 2013);
+            dasm_put(Dst, 1858, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
             break;
 
         case BOOL_TYPE:
             lua_pop(L, 1);
-            dasm_put(Dst, 2018);
+            dasm_put(Dst, 1890, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
             break;
 
         case INT8_TYPE:
             lua_pop(L, 1);
             if (mbr_ct->is_unsigned) {
-                dasm_put(Dst, 1427);
+                dasm_put(Dst, 1162);
             } else {
-                dasm_put(Dst, 1431);
+                dasm_put(Dst, 1166);
             }
-            dasm_put(Dst, 2023);
+            dasm_put(Dst, 1943, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
             break;
 
         case INT16_TYPE:
             lua_pop(L, 1);
             if (mbr_ct->is_unsigned) {
-                dasm_put(Dst, 1435);
+                dasm_put(Dst, 1170);
             } else {
-                dasm_put(Dst, 1439);
+                dasm_put(Dst, 1174);
             }
-            dasm_put(Dst, 2023);
+            dasm_put(Dst, 1943, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
             break;
 
         case INT32_TYPE:
         case ENUM_TYPE:
             lua_pop(L, 1);
             if (mbr_ct->is_unsigned) {
-                dasm_put(Dst, 2028);
+                dasm_put(Dst, 1993, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
             } else {
-                dasm_put(Dst, 2023);
+                dasm_put(Dst, 1943, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
             }
             break;
 
         case FLOAT_TYPE:
             lua_pop(L, 1);
-            dasm_put(Dst, 2033);
+            dasm_put(Dst, 2043, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
             break;
 
         case DOUBLE_TYPE:
             lua_pop(L, 1);
-            dasm_put(Dst, 2038);
+            dasm_put(Dst, 2048, (unsigned int)((uintptr_t)(perr)), (unsigned int)(((uintptr_t)(perr))>>32));
             break;
 
         default:

--- a/call_x86.dasc
+++ b/call_x86.dasc
@@ -21,6 +21,14 @@
 |.define RET_L, eax
 |.endif
 
+|.if X64
+|.define L_ARG, r12
+|.define TOP, r13
+|.else
+|.define L_ARG, rdi
+|.define TOP, rsi
+|.endif
+
 |.if X64WIN
 |
 |.macro call_rrrp, func, arg0, arg1, arg2, arg3
@@ -173,6 +181,146 @@
 |
 |.endif
 
+|.macro epilog
+|.if X64
+| mov TOP, [rbp-16]
+| mov L_ARG, [rbp-8]
+|.else
+| mov TOP, [rbp-8]
+| mov L_ARG, [rbp-4]
+|.endif
+| mov rsp, rbp
+| pop rbp
+| ret
+|.endmacro
+
+|.macro get_errno // note trashes registers
+| call extern GetLastError
+| mov64 rcx, perr
+| mov dword [rcx], eax
+|.endmacro
+
+|.macro too_few_arguments
+| mov ax, 0
+| call_rp extern luaL_error, L_ARG, &"too few arguments"
+|.endmacro
+
+|.macro too_many_arguments
+| mov ax, 0
+| call_rp extern luaL_error, L_ARG, &"too many arguments"
+|.endmacro
+
+|.macro lua_return_arg
+| mov eax, 1
+| epilog
+|.endmacro
+
+|.macro lua_return_void
+| get_errno
+| mov eax, 0
+| epilog
+|.endmacro
+
+|.macro lua_return_double
+|.if X64
+| movq qword [rsp+32], xmm0
+|.else
+| fstp qword [rsp+4] // note get_errno doesn't require any stack on x86
+|.endif
+|
+| get_errno
+|
+|.if X64WIN
+| movq xmm1, qword [rsp+32]
+| mov rcx, L_ARG
+|.elif X64
+| movq xmm0, qword [rsp+32]
+| mov rdi, L_ARG
+|.else
+| mov [rsp], L_ARG
+|.endif
+| call extern lua_pushnumber
+| lua_return_arg
+|.endmacro
+
+|.macro lua_return_bool
+| movzx eax, al
+| mov [rsp+32], eax
+| get_errno
+| mov eax, [rsp+32]
+| call_rr extern lua_pushboolean, L_ARG, rax
+| lua_return_arg
+|.endmacro
+
+|.macro lua_return_int
+| mov [rsp+32], eax
+| get_errno
+| mov eax, [rsp+32]
+| call_rr extern push_int, L_ARG, rax
+| lua_return_arg
+|.endmacro
+
+|.macro lua_return_uint
+| mov [rsp+32], eax
+| get_errno
+| mov eax, [rsp+32]
+| call_rr extern push_uint, L_ARG, rax
+| lua_return_arg
+|.endmacro
+
+|.macro lua_return_long
+| mov [rsp+32], rax
+| get_errno
+| mov rax, [rsp+32]
+| call_rr extern lua_pushinteger, L_ARG, rax
+| lua_return_arg
+|.endmacro
+
+|.macro lua_return_ulong
+| mov [rsp+32], rax
+| get_errno
+| mov rax, [rsp+32]
+| call_rr extern lua_pushinteger, L_ARG, rax
+| lua_return_arg
+|.endmacro
+
+|.macro save_registers
+| // use rbp relative so we store values in the outer stack frame
+|.if X64WIN
+| // use the provided shadow space for int registers above prev rbp and
+| // return address
+| mov [rbp+16], rcx
+| mov [rbp+24], rdx
+| mov [rbp+32], r8
+| mov [rbp+40], r9
+| // use the extra space we added for float registers
+| // -16 to store underneath previous value of L_ARG
+| movq qword [rbp-16], xmm0
+| movq qword [rbp-24], xmm1
+| movq qword [rbp-32], xmm2
+| movq qword [rbp-40], xmm3
+|.elif X64
+| movq qword [rbp-16], xmm0
+| movq qword [rbp-24], xmm1
+| movq qword [rbp-32], xmm2
+| movq qword [rbp-40], xmm3
+| movq qword [rbp-48], xmm4
+| movq qword [rbp-56], xmm5
+| movq qword [rbp-64], xmm6
+| movq qword [rbp-72], xmm7
+| mov [rbp-80], rdi
+| mov [rbp-88], rsi
+| mov [rbp-96], rdx
+| mov [rbp-104], rcx
+| mov [rbp-112], r8
+| mov [rbp-120], r9
+|.else
+| // fastcall, -8 to store underneath previous value of L_ARG
+| mov [rbp-8], ecx
+| mov [rbp-12], edx
+|.endif
+|.endmacro
+
 #if defined _WIN64 || defined __amd64__
 #define JUMP_SIZE 14
 #else
@@ -224,154 +372,7 @@ void compile_globals(struct jit* jit, lua_State* L)
      * stack
      */
 
-    |.if X64
-    |.define L_ARG, r12
-    |.define TOP, r13
-    |.else
-    |.define L_ARG, rdi
-    |.define TOP, rsi
-    |.endif
 
-    |.macro epilog
-    |.if X64
-    | mov TOP, [rbp-16]
-    | mov L_ARG, [rbp-8]
-    |.else
-    | mov TOP, [rbp-8]
-    | mov L_ARG, [rbp-4]
-    |.endif
-    | mov rsp, rbp
-    | pop rbp
-    | ret
-    |.endmacro
-
-    |.macro get_errno // note trashes registers
-    | call extern GetLastError
-    | mov64 rcx, perr
-    | mov dword [rcx], eax
-    |.endmacro
-
-    /* the general idea for the return functions is:
-     * 1) Save return value on stack
-     * 2) Call get_errno (this trashes the registers hence #1)
-     * 3) Unpack return value from stack
-     * 4) Call lua push function
-     * 5) Set eax to number of returned args (0 or 1)
-     * 6) Call return which pops our stack frame
-     */
-
-    |->lua_return_arg:
-    | mov eax, 1
-    | epilog
-
-    |->lua_return_void:
-    | get_errno
-    | mov eax, 0
-    | epilog
-
-    |->lua_return_double:
-    |.if X64
-    | movq qword [rsp+32], xmm0
-    |.else
-    | fstp qword [rsp+4] // note get_errno doesn't require any stack on x86
-    |.endif
-    |
-    | get_errno
-    |
-    |.if X64WIN
-    | movq xmm1, qword [rsp+32]
-    | mov rcx, L_ARG
-    |.elif X64
-    | movq xmm0, qword [rsp+32]
-    | mov rdi, L_ARG
-    |.else
-    | mov [rsp], L_ARG
-    |.endif
-    | call extern lua_pushnumber
-    | jmp ->lua_return_arg
-
-    |->lua_return_bool:
-    | movzx eax, al
-    | mov [rsp+32], eax
-    | get_errno
-    | mov eax, [rsp+32]
-    | call_rr extern lua_pushboolean, L_ARG, rax
-    | jmp ->lua_return_arg
-
-    |->lua_return_int:
-    | mov [rsp+32], eax
-    | get_errno
-    | mov eax, [rsp+32]
-    | call_rr extern push_int, L_ARG, rax
-    | jmp ->lua_return_arg
-
-    |->lua_return_uint:
-    | mov [rsp+32], eax
-    | get_errno
-    | mov eax, [rsp+32]
-    | call_rr extern push_uint, L_ARG, rax
-    | jmp ->lua_return_arg
-
-#if LUA_VERSION_NUM == 503
-    |->lua_return_long:
-    | mov [rsp+32], rax
-    | get_errno
-    | mov rax, [rsp+32]
-    | call_rr extern lua_pushinteger, L_ARG, rax
-    | jmp ->lua_return_arg
-
-    |->lua_return_ulong:
-    | mov [rsp+32], rax
-    | get_errno
-    | mov rax, [rsp+32]
-    | call_rr extern lua_pushinteger, L_ARG, rax
-    | jmp ->lua_return_arg
-#endif
-
-    |->too_few_arguments:
-    | mov ax, 0
-    | call_rp extern luaL_error, L_ARG, &"too few arguments"
-
-    |->too_many_arguments:
-    | mov ax, 0
-    | call_rp extern luaL_error, L_ARG, &"too many arguments"
-
-    |->save_registers:
-    | // use rbp relative so we store values in the outer stack frame
-    |.if X64WIN
-    | // use the provided shadow space for int registers above prev rbp and
-    | // return address
-    | mov [rbp+16], rcx
-    | mov [rbp+24], rdx
-    | mov [rbp+32], r8
-    | mov [rbp+40], r9
-    | // use the extra space we added for float registers
-    | // -16 to store underneath previous value of L_ARG
-    | movq qword [rbp-16], xmm0
-    | movq qword [rbp-24], xmm1
-    | movq qword [rbp-32], xmm2
-    | movq qword [rbp-40], xmm3
-    |.elif X64
-    | movq qword [rbp-16], xmm0
-    | movq qword [rbp-24], xmm1
-    | movq qword [rbp-32], xmm2
-    | movq qword [rbp-40], xmm3
-    | movq qword [rbp-48], xmm4
-    | movq qword [rbp-56], xmm5
-    | movq qword [rbp-64], xmm6
-    | movq qword [rbp-72], xmm7
-    | mov [rbp-80], rdi
-    | mov [rbp-88], rsi
-    | mov [rbp-96], rdx
-    | mov [rbp-104], rcx
-    | mov [rbp-112], r8
-    | mov [rbp-120], r9
-    |.else
-    | // fastcall, -8 to store underneath previous value of L_ARG
-    | mov [rbp-8], ecx
-    | mov [rbp-12], edx
-    |.endif
-    | ret
 
     compile(Dst, L, NULL, LUA_NOREF);
 }
@@ -689,12 +690,12 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
     |.if X64
     | // 8 to realign, 16 for return vars, 32 for local calls, rest to save registers
     | sub rsp, 8 + 16 + 32 + REGISTER_STACK_SPACE(ct)
-    | call ->save_registers
+    | save_registers
     |.else
     | // 4 to realign, 16 for return vars, 32 for local calls, rest to save registers
     | sub rsp, 4 + 16 + 32 + REGISTER_STACK_SPACE(ct)
     if (ct->calling_convention == FAST_CALL) {
-        | call ->save_registers
+        | save_registers
     }
     |.endif
 
@@ -1088,11 +1089,18 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
     | call_r extern lua_gettop, L_ARG
     | mov TOP, rax // no need for movzxd rax, eax - high word guarenteed to be zero by x86-64
     | cmp rax, nargs
-    | jl ->too_few_arguments
-
     if (!ct->has_var_arg) {
-        | jg ->too_many_arguments
+        | jge >2
+        | too_few_arguments
+        | 2:
+        | jle >1
+        | too_many_arguments
+    } else {
+        | jge >1
+        | too_few_arguments
     }
+
+    | 1:
 
     /* no need to zero extend eax returned by lua_gettop to rax as x86-64
      * preguarentees that the upper 32 bits will be zero */
@@ -1452,7 +1460,7 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
         | call_rrp extern push_cdata, L_ARG, lua_upvalueindex(num_upvals), mbr_ct
         | mov rcx, [rsp+32]
         | mov [rax], rcx // *(void**) cdata = val
-        | jmp ->lua_return_arg
+        | lua_return_arg
 
     } else {
         switch (mbr_ct->type) {
@@ -1464,16 +1472,16 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
             | call_rrp extern push_cdata, L_ARG, lua_upvalueindex(num_upvals), mbr_ct
             | mov rcx, [rsp+32]
             | mov [rax], rcx // *(cfunction**) cdata = val
-            | jmp ->lua_return_arg
+            | lua_return_arg
             break;
 
         case INT64_TYPE:
 #if LUA_VERSION_NUM == 503
             lua_pop(L, 1);
             if (mbr_ct->is_unsigned) {
-                | jmp ->lua_return_ulong
+                | lua_return_ulong
             } else {
-                | jmp ->lua_return_long
+                | lua_return_long
             }
 #else
             num_upvals++;
@@ -1499,7 +1507,7 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
             | mov [rax], rdx
             |.endif
             |
-            | jmp ->lua_return_arg
+            | lua_return_arg
 #endif
             break;
 
@@ -1529,7 +1537,7 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
             | mov [rax+4], ecx
             |.endif
             |
-            | jmp ->lua_return_arg
+            | lua_return_arg
             break;
 
         case COMPLEX_DOUBLE_TYPE:
@@ -1559,17 +1567,17 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
             | get_errno
             |.endif
             |
-            | jmp ->lua_return_arg
+            | lua_return_arg
             break;
 
         case VOID_TYPE:
             lua_pop(L, 1);
-            | jmp ->lua_return_void
+            | lua_return_void
             break;
 
         case BOOL_TYPE:
             lua_pop(L, 1);
-            | jmp ->lua_return_bool
+            | lua_return_bool
             break;
 
         case INT8_TYPE:
@@ -1579,7 +1587,7 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
             } else {
                 | movsx eax, al
             }
-            | jmp ->lua_return_int
+            | lua_return_int
             break;
 
         case INT16_TYPE:
@@ -1589,16 +1597,16 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
             } else {
                 | movsx eax, ax
             }
-            | jmp ->lua_return_int
+            | lua_return_int
             break;
 
         case INT32_TYPE:
         case ENUM_TYPE:
             lua_pop(L, 1);
             if (mbr_ct->is_unsigned) {
-                | jmp ->lua_return_uint
+                | lua_return_uint
             } else {
-                | jmp ->lua_return_int
+                | lua_return_int
             }
             break;
 
@@ -1607,12 +1615,12 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
             |.if X64
             | cvtss2sd xmm0, xmm0
             |.endif
-            | jmp ->lua_return_double
+            | lua_return_double
             break;
 
         case DOUBLE_TYPE:
             lua_pop(L, 1);
-            | jmp ->lua_return_double
+            | lua_return_double
             break;
 
         default:

--- a/call_x86.h
+++ b/call_x86.h
@@ -18,127 +18,109 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-static const unsigned char build_actionlist[1878] = {
-  248,10,184,1,0.0,0.0,0.0,139,117,252,248,139,125,252,252,137,252,236,93,195,
-  255,248,11,232,251,1,0,185,237,137,1,184,0,0.0,0.0,0.0,139,117,252,248,139,
-  125,252,252,137,252,236,93,195,255,248,12,221.0,92,36,4,232,251,1,0,185,237,
-  137,1,137,60,36,232,251,1,1,252,233,244,10,255,248,13,15.0,182,192,137,68,
-  36,32,232,251,1,0,185,237,137,1,139,68,36,32,137,68,36,4,137,60,36,232,251,
-  1,2,252,233,244,10,255,248,14,137,68,36,32,232,251,1,0,185,237,137,1,139,
-  68,36,32,137,68,36,4,137,60,36,232,251,1,3,252,233,244,10,255,248,15,137,
-  68,36,32,232,251,1,0,185,237,137,1,139,68,36,32,137,68,36,4,137,60,36,232,
-  251,1,4,252,233,244,10,255,248,16,137,68,36,32,232,251,1,0,185,237,137,1,
-  139,68,36,32,137,68,36,4,137,60,36,232,251,1,5,252,233,244,10,255,248,17,
-  137,68,36,32,232,251,1,0,185,237,137,1,139,68,36,32,137,68,36,4,137,60,36,
-  232,251,1,5,252,233,244,10,255,248,18,102,184,0,0.0,199.0,68,36,4,237,137,
-  60,36,232,251,1,6,255,248,19,102,184,0,0.0,199.0,68,36,4,237,137,60,36,232,
-  251,1,6,255,248,20,137,77,252,248,137,85,252,244,195,255,139,141,233,255,
-  139,141,233,139,149,233,255,137,132,253,36,233,255,137,132,253,36,233,137,
-  148,253,36,233,255,221.0,133,233,255,217.0,133,233,255,252,243.0,15.0,126,
-  133,233,255,252,243.0,15.0,90,133,233,255,221.0,156,253,36,233,255,217.0,
-  156,253,36,233,255,102.0,15.0,214,132,253,36,233,255,252,242.0,15.0,90,192,
-  102.0,15.0,214,132,253,36,233,255,252,242.0,15.0,90,192,102.0,15.0,126,132,
-  253,36,233,255,85,137,229,87,129.0,252,236,239,255,232,244,20,255,191,237,
-  255,199.0,68,36,8,237,199.0,68,36,4,237,137,60,36,232,251,1,7,255,199.0,68,
-  36,8,237,199.0,68,36,4,252,255,252,255.0,252,255.0,252,255.0,137,60,36,232,
-  251,1,7,255,199.0,68,36,8,237,199.0,68,36,4,237,137,60,36,232,251,1,7,199.0,
-  68,36,8,237,199.0,68,36,4,252,255,252,255.0,252,255.0,252,255.0,137,60,36,
-  232,251,1,8,255,137,8,199.0,68,36,4,252,254,252,255.0,252,255.0,252,255.0,
-  137,60,36,232,251,1,9,255,199.0,68,36,8,237,199.0,68,36,4,0,0.0,0.0,0.0,137,
-  60,36,232,251,1,8,255,137,8,137,80,4,255,137,8,255,102.0,15.0,214,0,255,217.0,
-  24,255,217.0,88,4,255,221.0,24,255,221.0,88,8,255,221.0,92,36,4,137,60,36,
-  232,251,1,1,255,15.0,182,201,137,76,36,4,137,60,36,232,251,1,2,255,15.0,182,
-  201,255,15.0,190,201,255,137,76,36,4,137,60,36,232,251,1,3,255,15.0,183,201,
-  255,15.0,191,201,255,137,76,36,4,137,60,36,232,251,1,4,255,199.0,68,36,12,
-  0,0.0,0.0,0.0,199.0,68,36,8,237,199.0,68,36,4,237,137,60,36,232,251,1,10,
-  255,199.0,68,36,8,237,199.0,68,36,4,252,254,252,255.0,252,255.0,252,255.0,
-  137,60,36,232,251,1,7,199.0,68,36,12,237,199.0,68,36,8,252,255,252,255.0,
-  252,255.0,252,255.0,199.0,68,36,4,252,254,252,255.0,252,255.0,252,255.0,137,
-  60,36,232,251,1,11,137,68,36,32,199.0,68,36,4,252,252,252,255.0,252,255.0,
-  252,255.0,137,60,36,232,251,1,12,139,68,36,32,255,199.0,68,36,8,237,199.0,
-  68,36,4,252,254,252,255.0,252,255.0,252,255.0,137,60,36,232,251,1,7,199.0,
-  68,36,12,237,199.0,68,36,8,252,255,252,255.0,252,255.0,252,255.0,199.0,68,
-  36,4,252,254,252,255.0,252,255.0,252,255.0,137,60,36,232,251,1,13,137,68,
-  36,32,199.0,68,36,4,252,252,252,255.0,252,255.0,252,255.0,137,60,36,232,251,
-  1,12,139,68,36,32,255,199.0,68,36,4,252,254,252,255.0,252,255.0,252,255.0,
-  137,60,36,232,251,1,12,255,199.0,68,36,4,252,255,252,255.0,252,255.0,252,
-  255.0,137,60,36,232,251,1,14,255,199.0,68,36,4,252,255,252,255.0,252,255.0,
-  252,255.0,137,60,36,232,251,1,15,255,137,68,36,32,199.0,68,36,4,252,253,252,
-  255.0,252,255.0,252,255.0,137,60,36,232,251,1,12,139,68,36,32,255,199.0,68,
-  36,4,252,255,252,255.0,252,255.0,252,255.0,137,60,36,232,251,1,16,255,199.0,
-  68,36,4,252,255,252,255.0,252,255.0,252,255.0,137,60,36,232,251,1,17,255,
-  137,68,36,32,137,84,36,36,199.0,68,36,4,252,253,252,255.0,252,255.0,252,255.0,
-  137,60,36,232,251,1,12,139,68,36,32,139,84,36,36,255,199.0,68,36,4,252,255,
-  252,255.0,252,255.0,252,255.0,137,60,36,232,251,1,18,137,68,36,32,199.0,68,
-  36,4,252,253,252,255.0,252,255.0,252,255.0,137,60,36,232,251,1,12,139,68,
-  36,32,255,199.0,68,36,4,252,255,252,255.0,252,255.0,252,255.0,137,60,36,232,
-  251,1,19,255,221.0,92,36,32,199.0,68,36,4,252,253,252,255.0,252,255.0,252,
-  255.0,137,60,36,232,251,1,12,221.0,68,36,32,255,199.0,68,36,4,252,255,252,
-  255.0,252,255.0,252,255.0,137,60,36,232,251,1,20,137,68,36,32,137,84,36,36,
-  199.0,68,36,4,252,253,252,255.0,252,255.0,252,255.0,137,60,36,232,251,1,12,
-  139,68,36,32,139,84,36,36,255,199.0,68,36,4,252,255,252,255.0,252,255.0,252,
-  255.0,137,60,36,232,251,1,21,102.0,15.0,214,68,36,32,102.0,15.0,214,76,36,
-  40,199.0,68,36,4,252,253,252,255.0,252,255.0,252,255.0,137,60,36,232,251,
-  1,12,252,243.0,15.0,126,68,36,32,252,243.0,15.0,126,76,36,40,255,139,141,
-  233,199.0,68,36,8,252,255,252,255.0,252,255.0,252,255.0,137,124,36,4,137,
-  12,36,232,251,1,21,131.0,252,236,4,199.0,68,36,4,252,253,252,255.0,252,255.0,
-  252,255.0,137,60,36,232,251,1,12,255,139,125,252,252,137,252,236,93,194,236,
-  255,85,137,229,87,86,139,189,233,131.0,252,236,16,137,60,36,232,251,1,22,
-  137,198,129.0,252,248,239,15.0,140,244,18,255,15.0,143,244,19,255,193.0,224,
-  4,41,196,129.0,252,236,239,255,199.0,68,36,8,237,199.0,68,36,4,0,0.0,0.0,
-  0.0,137,60,36,232,251,1,8,131.0,252,236,16,255,199.0,68,36,12,237,199.0,68,
-  36,8,237,199.0,68,36,4,237,137,60,36,232,251,1,11,255,199.0,68,36,12,237,
-  199.0,68,36,8,237,199.0,68,36,4,237,137,60,36,232,251,1,23,255,199.0,68,36,
-  12,237,199.0,68,36,8,237,199.0,68,36,4,237,137,60,36,232,251,1,13,255,199.0,
-  68,36,4,237,137,60,36,232,251,1,15,255,15.0,182,192,255,15.0,190,192,255,
-  15.0,183,192,255,15.0,191,192,255,199.0,68,36,4,237,137,60,36,232,251,1,15,
-  131.0,252,248,0,15.0,149.0,208,15.0,182,192,255,199.0,68,36,4,237,137,60,
-  36,232,251,1,14,255,199.0,68,36,4,237,137,60,36,232,251,1,18,255,199.0,68,
-  36,4,237,137,60,36,232,251,1,16,255,199.0,68,36,4,237,137,60,36,232,251,1,
-  17,255,199.0,68,36,4,237,137,60,36,232,251,1,19,255,199.0,68,36,4,237,137,
-  60,36,232,251,1,21,255,252,243.0,15.0,126,193,255,141,132,253,36,233,131.0,
-  252,236,4,199.0,68,36,8,237,137,124,36,4,137,4,36,232,251,1,21,255,199.0,
-  68,36,4,237,137,60,36,232,251,1,20,255,199.0,68,36,4,237,137,60,36,232,251,
-  1,20,137,4,36,217.0,4,36,255,137,20,36,217.0,4,36,255,137,224,129.0,192,239,
-  137,68,36,12,137,116,36,8,199.0,68,36,4,237,137,60,36,232,251,1,24,255,185,
-  237,139,1,137,4,36,232,251,1,25,255,131.0,196,32,255,139,148,253,36,233,255,
-  139,12,36,255,129.0,196,239,255,232,251,1,26,131.0,252,236,48,255,137,68,
-  36,32,232,251,1,0,185,237,137,1,199.0,68,36,8,237,199.0,68,36,4,237,137,60,
-  36,232,251,1,8,139,76,36,32,137,8,252,233,244,10,255,252,233,244,17,255,252,
-  233,244,16,255,137,84,36,36,137,68,36,32,232,251,1,0,185,237,137,1,199.0,
-  68,36,8,237,199.0,68,36,4,0,0.0,0.0,0.0,137,60,36,232,251,1,8,139,76,36,36,
-  139,84,36,32,137,72,4,137,16,252,233,244,10,255,137,68,36,32,137,84,36,36,
-  232,251,1,0,185,237,137,1,199.0,68,36,8,237,199.0,68,36,4,237,137,60,36,232,
-  251,1,8,139,76,36,32,137,8,139,76,36,36,137,72,4,252,233,244,10,255,131.0,
-  252,236,4,232,251,1,0,185,237,137,1,252,233,244,10,255,252,233,244,11,255,
-  252,233,244,13,255,252,233,244,14,255,252,233,244,15,255,252,233,244,12,255
+static const unsigned char build_actionlist[1915] = {
+  139,141,233,255,139,141,233,139,149,233,255,137,132,253,36,233,255,137,132,
+  253,36,233,137,148,253,36,233,255,221,133,233,255,217,133,233,255,252,243,
+  15,126,133,233,255,252,243,15,90,133,233,255,221,156,253,36,233,255,217,156,
+  253,36,233,255,102,15,214,132,253,36,233,255,252,242,15,90,192,102,15,214,
+  132,253,36,233,255,252,242,15,90,192,102,15,126,132,253,36,233,255,85,137,
+  229,87,129,252,236,239,255,137,77,252,248,137,85,252,244,255,191,237,255,
+  199,68,36,8,237,199,68,36,4,237,137,60,36,232,251,1,0,255,199,68,36,8,237,
+  199,68,36,4,252,255,252,255,252,255,252,255,137,60,36,232,251,1,0,255,199,
+  68,36,8,237,199,68,36,4,237,137,60,36,232,251,1,0,199,68,36,8,237,199,68,
+  36,4,252,255,252,255,252,255,252,255,137,60,36,232,251,1,1,255,137,8,199,
+  68,36,4,252,254,252,255,252,255,252,255,137,60,36,232,251,1,2,255,199,68,
+  36,8,237,199,68,36,4,0,0,0,0,137,60,36,232,251,1,1,255,137,8,137,80,4,255,
+  137,8,255,102,15,214,0,255,217,24,255,217,88,4,255,221,24,255,221,88,8,255,
+  221,92,36,4,137,60,36,232,251,1,3,255,15,182,201,137,76,36,4,137,60,36,232,
+  251,1,4,255,15,182,201,255,15,190,201,255,137,76,36,4,137,60,36,232,251,1,
+  5,255,15,183,201,255,15,191,201,255,137,76,36,4,137,60,36,232,251,1,6,255,
+  199,68,36,12,0,0,0,0,199,68,36,8,237,199,68,36,4,237,137,60,36,232,251,1,
+  7,255,199,68,36,8,237,199,68,36,4,252,254,252,255,252,255,252,255,137,60,
+  36,232,251,1,0,199,68,36,12,237,199,68,36,8,252,255,252,255,252,255,252,255,
+  199,68,36,4,252,254,252,255,252,255,252,255,137,60,36,232,251,1,8,137,68,
+  36,32,199,68,36,4,252,252,252,255,252,255,252,255,137,60,36,232,251,1,9,139,
+  68,36,32,255,199,68,36,8,237,199,68,36,4,252,254,252,255,252,255,252,255,
+  137,60,36,232,251,1,0,199,68,36,12,237,199,68,36,8,252,255,252,255,252,255,
+  252,255,199,68,36,4,252,254,252,255,252,255,252,255,137,60,36,232,251,1,10,
+  137,68,36,32,199,68,36,4,252,252,252,255,252,255,252,255,137,60,36,232,251,
+  1,9,139,68,36,32,255,199,68,36,4,252,254,252,255,252,255,252,255,137,60,36,
+  232,251,1,9,255,199,68,36,4,252,255,252,255,252,255,252,255,137,60,36,232,
+  251,1,11,255,199,68,36,4,252,255,252,255,252,255,252,255,137,60,36,232,251,
+  1,12,255,137,68,36,32,199,68,36,4,252,253,252,255,252,255,252,255,137,60,
+  36,232,251,1,9,139,68,36,32,255,199,68,36,4,252,255,252,255,252,255,252,255,
+  137,60,36,232,251,1,13,255,199,68,36,4,252,255,252,255,252,255,252,255,137,
+  60,36,232,251,1,14,255,137,68,36,32,137,84,36,36,199,68,36,4,252,253,252,
+  255,252,255,252,255,137,60,36,232,251,1,9,139,68,36,32,139,84,36,36,255,199,
+  68,36,4,252,255,252,255,252,255,252,255,137,60,36,232,251,1,15,137,68,36,
+  32,199,68,36,4,252,253,252,255,252,255,252,255,137,60,36,232,251,1,9,139,
+  68,36,32,255,199,68,36,4,252,255,252,255,252,255,252,255,137,60,36,232,251,
+  1,16,255,221,92,36,32,199,68,36,4,252,253,252,255,252,255,252,255,137,60,
+  36,232,251,1,9,221,68,36,32,255,199,68,36,4,252,255,252,255,252,255,252,255,
+  137,60,36,232,251,1,17,137,68,36,32,137,84,36,36,199,68,36,4,252,253,252,
+  255,252,255,252,255,137,60,36,232,251,1,9,139,68,36,32,139,84,36,36,255,199,
+  68,36,4,252,255,252,255,252,255,252,255,137,60,36,232,251,1,18,102,15,214,
+  68,36,32,102,15,214,76,36,40,199,68,36,4,252,253,252,255,252,255,252,255,
+  137,60,36,232,251,1,9,252,243,15,126,68,36,32,252,243,15,126,76,36,40,255,
+  139,141,233,199,68,36,8,252,255,252,255,252,255,252,255,137,124,36,4,137,
+  12,36,232,251,1,18,131,252,236,4,199,68,36,4,252,253,252,255,252,255,252,
+  255,137,60,36,232,251,1,9,255,139,125,252,252,137,252,236,93,194,236,255,
+  85,137,229,87,86,139,189,233,131,252,236,16,137,60,36,232,251,1,19,137,198,
+  129,252,248,239,255,15,141,244,248,102,184,0,0,199,68,36,4,237,137,60,36,
+  232,251,1,20,248,2,15,142,244,247,102,184,0,0,199,68,36,4,237,137,60,36,232,
+  251,1,20,255,15,141,244,247,102,184,0,0,199,68,36,4,237,137,60,36,232,251,
+  1,20,255,248,1,255,193,224,4,41,196,129,252,236,239,255,199,68,36,8,237,199,
+  68,36,4,0,0,0,0,137,60,36,232,251,1,1,131,252,236,16,255,199,68,36,12,237,
+  199,68,36,8,237,199,68,36,4,237,137,60,36,232,251,1,8,255,199,68,36,12,237,
+  199,68,36,8,237,199,68,36,4,237,137,60,36,232,251,1,21,255,199,68,36,12,237,
+  199,68,36,8,237,199,68,36,4,237,137,60,36,232,251,1,10,255,199,68,36,4,237,
+  137,60,36,232,251,1,12,255,15,182,192,255,15,190,192,255,15,183,192,255,15,
+  191,192,255,199,68,36,4,237,137,60,36,232,251,1,12,131,252,248,0,15,149,208,
+  15,182,192,255,199,68,36,4,237,137,60,36,232,251,1,11,255,199,68,36,4,237,
+  137,60,36,232,251,1,15,255,199,68,36,4,237,137,60,36,232,251,1,13,255,199,
+  68,36,4,237,137,60,36,232,251,1,14,255,199,68,36,4,237,137,60,36,232,251,
+  1,16,255,199,68,36,4,237,137,60,36,232,251,1,18,255,252,243,15,126,193,255,
+  141,132,253,36,233,131,252,236,4,199,68,36,8,237,137,124,36,4,137,4,36,232,
+  251,1,18,255,199,68,36,4,237,137,60,36,232,251,1,17,255,199,68,36,4,237,137,
+  60,36,232,251,1,17,137,4,36,217,4,36,255,137,20,36,217,4,36,255,137,224,129,
+  192,239,137,68,36,12,137,116,36,8,199,68,36,4,237,137,60,36,232,251,1,22,
+  255,185,237,139,1,137,4,36,232,251,1,23,255,131,196,32,255,139,148,253,36,
+  233,255,139,12,36,255,129,196,239,255,232,251,1,24,131,252,236,48,255,137,
+  68,36,32,232,251,1,25,185,237,137,1,199,68,36,8,237,199,68,36,4,237,137,60,
+  36,232,251,1,1,139,76,36,32,137,8,184,1,0,0,0,139,117,252,248,139,125,252,
+  252,137,252,236,93,195,255,137,68,36,32,232,251,1,25,185,237,137,1,139,68,
+  36,32,137,68,36,4,137,60,36,232,251,1,26,184,1,0,0,0,139,117,252,248,139,
+  125,252,252,137,252,236,93,195,255,137,84,36,36,137,68,36,32,232,251,1,25,
+  185,237,137,1,199,68,36,8,237,199,68,36,4,0,0,0,0,137,60,36,232,251,1,1,139,
+  76,36,36,139,84,36,32,137,72,4,137,16,184,1,0,0,0,139,117,252,248,139,125,
+  252,252,137,252,236,93,195,255,137,68,36,32,137,84,36,36,232,251,1,25,185,
+  237,137,1,199,68,36,8,237,199,68,36,4,237,137,60,36,232,251,1,1,139,76,36,
+  32,137,8,139,76,36,36,137,72,4,184,1,0,0,0,139,117,252,248,139,125,252,252,
+  137,252,236,93,195,255,131,252,236,4,232,251,1,25,185,237,137,1,184,1,0,0,
+  0,139,117,252,248,139,125,252,252,137,252,236,93,195,255,232,251,1,25,185,
+  237,137,1,184,0,0,0,0,139,117,252,248,139,125,252,252,137,252,236,93,195,
+  255,15,182,192,137,68,36,32,232,251,1,25,185,237,137,1,139,68,36,32,137,68,
+  36,4,137,60,36,232,251,1,4,184,1,0,0,0,139,117,252,248,139,125,252,252,137,
+  252,236,93,195,255,137,68,36,32,232,251,1,25,185,237,137,1,139,68,36,32,137,
+  68,36,4,137,60,36,232,251,1,5,184,1,0,0,0,139,117,252,248,139,125,252,252,
+  137,252,236,93,195,255,137,68,36,32,232,251,1,25,185,237,137,1,139,68,36,
+  32,137,68,36,4,137,60,36,232,251,1,6,184,1,0,0,0,139,117,252,248,139,125,
+  252,252,137,252,236,93,195,255,221,92,36,4,232,251,1,25,185,237,137,1,137,
+  60,36,232,251,1,3,184,1,0,0,0,139,117,252,248,139,125,252,252,137,252,236,
+  93,195,255
 };
 
 static const char *const globnames[] = {
-  "lua_return_arg",
-  "lua_return_void",
-  "lua_return_double",
-  "lua_return_bool",
-  "lua_return_int",
-  "lua_return_uint",
-  "lua_return_long",
-  "lua_return_ulong",
-  "too_few_arguments",
-  "too_many_arguments",
-  "save_registers",
   (const char *)0
 };
 static const char *const extnames[] = {
-  "GetLastError",
+  "lua_rawgeti",
+  "push_cdata",
+  "lua_remove",
   "lua_pushnumber",
   "lua_pushboolean",
   "push_int",
   "push_uint",
-  "lua_pushinteger",
-  "luaL_error",
-  "lua_rawgeti",
-  "push_cdata",
-  "lua_remove",
   "lua_callk",
   "check_typed_pointer",
   "lua_settop",
@@ -152,12 +134,29 @@ static const char *const extnames[] = {
   "check_complex_float",
   "check_complex_double",
   "lua_gettop",
+  "luaL_error",
   "check_typed_cfunction",
   "unpack_varargs_stack",
   "SetLastError",
   "FUNCTION",
+  "GetLastError",
+  "lua_pushinteger",
   (const char *)0
 };
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -211,42 +210,6 @@ void compile_globals(struct jit* jit, lua_State* L)
     /* Note the various call_* functions want 32 bytes of 16 byte aligned
      * stack
      */
-
-
-
-
-    /* the general idea for the return functions is:
-     * 1) Save return value on stack
-     * 2) Call get_errno (this trashes the registers hence #1)
-     * 3) Unpack return value from stack
-     * 4) Call lua push function
-     * 5) Set eax to number of returned args (0 or 1)
-     * 6) Call return which pops our stack frame
-     */
-
-    dasm_put(Dst, 0);
-
-    dasm_put(Dst, 21, perr);
-
-    dasm_put(Dst, 50, perr);
-
-    dasm_put(Dst, 76, perr);
-
-    dasm_put(Dst, 113, perr);
-
-    dasm_put(Dst, 147, perr);
-
-#if LUA_VERSION_NUM == 503
-    dasm_put(Dst, 181, perr);
-
-    dasm_put(Dst, 215, perr);
-#endif
-
-    dasm_put(Dst, 249, (ptrdiff_t)("too few arguments"));
-
-    dasm_put(Dst, 268, (ptrdiff_t)("too many arguments"));
-
-    dasm_put(Dst, 287);
 
     compile(Dst, L, NULL, LUA_NOREF);
 }
@@ -356,25 +319,25 @@ static void get_int(Dst_DECL, const struct ctype* ct, struct reg_alloc* reg, int
     /* grab the register from the shadow space */
 #ifdef _WIN64
     if (reg->regs < MAX_REGISTERS(ct)) {
-        dasm_put(Dst, 299, 16 + 8*reg->regs);
+        dasm_put(Dst, 0, 16 + 8*reg->regs);
         reg->regs++;
     }
 #elif __amd64__
     if (reg->ints < MAX_INT_REGISTERS(ct)) {
-        dasm_put(Dst, 299, - 80 - 8*reg->ints);
+        dasm_put(Dst, 0, - 80 - 8*reg->ints);
         reg->ints++;
     }
 #else
     if (!is_int64 && reg->ints < MAX_INT_REGISTERS(ct)) {
-        dasm_put(Dst, 299, - 8 - 4*reg->ints);
+        dasm_put(Dst, 0, - 8 - 4*reg->ints);
         reg->ints++;
     }
 #endif
     else if (is_int64) {
-        dasm_put(Dst, 303, reg->off, reg->off + 4);
+        dasm_put(Dst, 4, reg->off, reg->off + 4);
         reg->off += 8;
     } else {
-        dasm_put(Dst, 299, reg->off);
+        dasm_put(Dst, 0, reg->off);
         reg->off += 4;
     }
 }
@@ -383,17 +346,17 @@ static void add_int(Dst_DECL, const struct ctype* ct, struct reg_alloc* reg, int
 {
 #ifdef _WIN64
     if (reg->regs < MAX_REGISTERS(ct)) {
-        dasm_put(Dst, 310, 32 + 8*(reg->regs));
+        dasm_put(Dst, 11, 32 + 8*(reg->regs));
         reg->is_int[reg->regs++] = 1;
     }
 #elif __amd64__
     if (reg->ints < MAX_INT_REGISTERS(ct)) {
-        dasm_put(Dst, 310, 32 + 8*reg->ints);
+        dasm_put(Dst, 11, 32 + 8*reg->ints);
         reg->ints++;
     }
 #else
     if (!is_int64 && reg->ints < MAX_INT_REGISTERS(ct)) {
-        dasm_put(Dst, 310, 32 + 4*reg->ints);
+        dasm_put(Dst, 11, 32 + 4*reg->ints);
         reg->ints++;
     }
 #endif
@@ -404,10 +367,10 @@ static void add_int(Dst_DECL, const struct ctype* ct, struct reg_alloc* reg, int
         }
 #endif
         if (is_int64) {
-            dasm_put(Dst, 316, reg->off, reg->off + 4);
+            dasm_put(Dst, 17, reg->off, reg->off + 4);
             reg->off += 8;
         } else {
-            dasm_put(Dst, 310, reg->off);
+            dasm_put(Dst, 11, reg->off);
             reg->off += 4;
         }
     }
@@ -418,10 +381,10 @@ static void get_float(Dst_DECL, const struct ctype* ct, struct reg_alloc* reg, i
 #if !defined _WIN64 && !defined __amd64__
     assert(MAX_FLOAT_REGISTERS(ct) == 0);
     if (is_double) {
-        dasm_put(Dst, 327, reg->off);
+        dasm_put(Dst, 28, reg->off);
         reg->off += 8;
     } else {
-        dasm_put(Dst, 331, reg->off);
+        dasm_put(Dst, 32, reg->off);
         reg->off += 4;
     }
 #else
@@ -444,9 +407,9 @@ static void get_float(Dst_DECL, const struct ctype* ct, struct reg_alloc* reg, i
     }
 
     if (is_double) {
-        dasm_put(Dst, 335, off);
+        dasm_put(Dst, 36, off);
     } else {
-        dasm_put(Dst, 342, off);
+        dasm_put(Dst, 43, off);
     }
 #endif
 }
@@ -456,10 +419,10 @@ static void add_float(Dst_DECL, const struct ctype* ct, struct reg_alloc* reg, i
 #if !defined _WIN64 && !defined __amd64__
     assert(MAX_FLOAT_REGISTERS(ct) == 0);
     if (is_double) {
-        dasm_put(Dst, 349, reg->off);
+        dasm_put(Dst, 50, reg->off);
         reg->off += 8;
     } else {
-        dasm_put(Dst, 355, reg->off);
+        dasm_put(Dst, 56, reg->off);
         reg->off += 4;
     }
 #else
@@ -467,28 +430,28 @@ static void add_float(Dst_DECL, const struct ctype* ct, struct reg_alloc* reg, i
 #ifdef _WIN64
     if (reg->regs < MAX_REGISTERS(ct)) {
         if (is_double) {
-            dasm_put(Dst, 361, 32 + 8*(reg->regs));
+            dasm_put(Dst, 62, 32 + 8*(reg->regs));
         } else {
-            dasm_put(Dst, 369, 32 + 8*(reg->regs));
+            dasm_put(Dst, 70, 32 + 8*(reg->regs));
         }
         reg->is_float[reg->regs++] = 1;
     }
 #else
     if (reg->floats < MAX_FLOAT_REGISTERS(ct)) {
         if (is_double) {
-            dasm_put(Dst, 361, 32 + 8*(MAX_INT_REGISTERS(ct) + reg->floats));
+            dasm_put(Dst, 62, 32 + 8*(MAX_INT_REGISTERS(ct) + reg->floats));
         } else {
-            dasm_put(Dst, 369, 32 + 8*(MAX_INT_REGISTERS(ct) + reg->floats));
+            dasm_put(Dst, 70, 32 + 8*(MAX_INT_REGISTERS(ct) + reg->floats));
         }
         reg->floats++;
     }
 #endif
 
     else if (is_double) {
-        dasm_put(Dst, 361, reg->off);
+        dasm_put(Dst, 62, reg->off);
         reg->off += 8;
     } else {
-        dasm_put(Dst, 382, reg->off);
+        dasm_put(Dst, 83, reg->off);
         reg->off += 4;
     }
 #endif
@@ -544,22 +507,22 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
 
     // setup a stack frame to hold args for the call into lua_call
 
-    dasm_put(Dst, 395, 4 + 16 + 32 + REGISTER_STACK_SPACE(ct));
+    dasm_put(Dst, 96, 4 + 16 + 32 + REGISTER_STACK_SPACE(ct));
     if (ct->calling_convention == FAST_CALL) {
-        dasm_put(Dst, 404);
+        dasm_put(Dst, 105);
     }
 
     // hardcode the lua_State* value into the assembly
-    dasm_put(Dst, 408, L);
+    dasm_put(Dst, 114, L);
 
     /* get the upval table */
-    dasm_put(Dst, 411, ref, LUA_REGISTRYINDEX);
+    dasm_put(Dst, 117, ref, LUA_REGISTRYINDEX);
 
     /* get the lua function */
     lua_pushvalue(L, fidx);
     lua_rawseti(L, -2, ++num_upvals);
     assert(num_upvals == CALLBACK_FUNC_USR_IDX);
-    dasm_put(Dst, 429, num_upvals);
+    dasm_put(Dst, 135, num_upvals);
 
 #if !defined _WIN64 && !defined __amd64__
     lua_rawgeti(L, ct_usr, 0);
@@ -584,90 +547,90 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
             /* on the lua stack in the callback:
              * upval tbl, lua func, i-1 args
              */
-            dasm_put(Dst, 454, num_upvals-1, -i-1, mt);
+            dasm_put(Dst, 160, num_upvals-1, -i-1, mt);
             get_pointer(Dst, ct, &reg);
-            dasm_put(Dst, 496);
+            dasm_put(Dst, 202);
         } else {
             switch (mt->type) {
             case INT64_TYPE:
                 lua_getuservalue(L, -1);
                 lua_rawseti(L, -3, ++num_upvals); /* mt */
                 lua_pop(L, 1);
-                dasm_put(Dst, 518, mt);
+                dasm_put(Dst, 224, mt);
                 get_int(Dst, ct, &reg, 1);
-                dasm_put(Dst, 539);
+                dasm_put(Dst, 245);
                 break;
 
             case INTPTR_TYPE:
                 lua_getuservalue(L, -1);
                 lua_rawseti(L, -3, ++num_upvals); /* mt */
                 lua_pop(L, 1);
-                dasm_put(Dst, 518, mt);
+                dasm_put(Dst, 224, mt);
                 get_pointer(Dst, ct, &reg);
-                dasm_put(Dst, 545);
+                dasm_put(Dst, 251);
                 break;
 
             case COMPLEX_FLOAT_TYPE:
                 lua_pop(L, 1);
 #if defined _WIN64 || defined __amd64__
                 /* complex floats are two floats packed into a double */
-                dasm_put(Dst, 518, mt);
+                dasm_put(Dst, 224, mt);
                 get_float(Dst, ct, &reg, 1);
-                dasm_put(Dst, 548);
+                dasm_put(Dst, 254);
 #else
                 /* complex floats are real followed by imag on the stack */
-                dasm_put(Dst, 518, mt);
+                dasm_put(Dst, 224, mt);
                 get_float(Dst, ct, &reg, 0);
-                dasm_put(Dst, 553);
+                dasm_put(Dst, 259);
                 get_float(Dst, ct, &reg, 0);
-                dasm_put(Dst, 556);
+                dasm_put(Dst, 262);
 #endif
                 break;
 
             case COMPLEX_DOUBLE_TYPE:
                 lua_pop(L, 1);
-                dasm_put(Dst, 518, mt);
+                dasm_put(Dst, 224, mt);
                 /* real */
                 get_float(Dst, ct, &reg, 1);
-                dasm_put(Dst, 560);
+                dasm_put(Dst, 266);
                 /* imag */
                 get_float(Dst, ct, &reg, 1);
-                dasm_put(Dst, 563);
+                dasm_put(Dst, 269);
                 break;
 
             case FLOAT_TYPE:
             case DOUBLE_TYPE:
                 lua_pop(L, 1);
                 get_float(Dst, ct, &reg, mt->type == DOUBLE_TYPE);
-                dasm_put(Dst, 567);
+                dasm_put(Dst, 273);
                 break;
 
             case BOOL_TYPE:
                 lua_pop(L, 1);
                 get_int(Dst, ct, &reg, 0);
-                dasm_put(Dst, 579);
+                dasm_put(Dst, 285);
                 break;
 
             case INT8_TYPE:
                 lua_pop(L, 1);
                 get_int(Dst, ct, &reg, 0);
                 if (mt->is_unsigned) {
-                    dasm_put(Dst, 594);
+                    dasm_put(Dst, 300);
                 } else {
-                    dasm_put(Dst, 598);
+                    dasm_put(Dst, 304);
                 }
-                dasm_put(Dst, 602);
+                dasm_put(Dst, 308);
                 break;
 
             case INT16_TYPE:
                 lua_pop(L, 1);
                 get_int(Dst, ct, &reg, 0);
                 if (mt->is_unsigned) {
-                    dasm_put(Dst, 614);
+                    dasm_put(Dst, 320);
                 } else {
-                    dasm_put(Dst, 618);
+                    dasm_put(Dst, 324);
                 }
-                dasm_put(Dst, 602);
+                dasm_put(Dst, 308);
                 break;
 
             case ENUM_TYPE:
@@ -675,9 +638,9 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
                 lua_pop(L, 1);
                 get_int(Dst, ct, &reg, 0);
                 if (mt->is_unsigned) {
-                    dasm_put(Dst, 622);
+                    dasm_put(Dst, 328);
                 } else {
-                    dasm_put(Dst, 602);
+                    dasm_put(Dst, 308);
                 }
                 break;
 
@@ -690,7 +653,7 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
     lua_rawgeti(L, ct_usr, 0);
     mt = (const struct ctype*) lua_touserdata(L, -1);
 
-    dasm_put(Dst, 634, (mt->pointers || mt->is_reference || mt->type != VOID_TYPE) ? 1 : 0, nargs);
+    dasm_put(Dst, 340, (mt->pointers || mt->is_reference || mt->type != VOID_TYPE) ? 1 : 0, nargs);
 
     // Unpack the return argument if not "void", also clean-up the lua stack
     // to remove the return argument and bind table. Use lua_settop rather
@@ -699,7 +662,7 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
         lua_getuservalue(L, -1);
         lua_rawseti(L, -3, ++num_upvals); /* usr value */
         lua_rawseti(L, -2, ++num_upvals); /* mt */
-        dasm_put(Dst, 660, num_upvals-1, mt);
+        dasm_put(Dst, 366, num_upvals-1, mt);
 
     } else {
         switch (mt->type) {
@@ -707,12 +670,12 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
             lua_getuservalue(L, -1);
             lua_rawseti(L, -3, ++num_upvals); /* usr value */
             lua_rawseti(L, -2, ++num_upvals); /* mt */
-            dasm_put(Dst, 748, num_upvals-1, mt);
+            dasm_put(Dst, 454, num_upvals-1, mt);
             break;
 
         case VOID_TYPE:
             lua_pop(L, 1);
-            dasm_put(Dst, 836);
+            dasm_put(Dst, 542);
             break;
 
         case BOOL_TYPE:
@@ -721,38 +684,38 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
         case INT32_TYPE:
             lua_pop(L, 1);
             if (mt->is_unsigned) {
-                dasm_put(Dst, 856);
+                dasm_put(Dst, 562);
             } else {
-                dasm_put(Dst, 876);
+                dasm_put(Dst, 582);
             }
-            dasm_put(Dst, 896);
+            dasm_put(Dst, 602);
             break;
 
         case INT64_TYPE:
             lua_pop(L, 1);
 
             if (mt->is_unsigned) {
-                dasm_put(Dst, 924);
+                dasm_put(Dst, 630);
             } else {
-                dasm_put(Dst, 944);
+                dasm_put(Dst, 650);
             }
 
-            dasm_put(Dst, 964);
+            dasm_put(Dst, 670);
             break;
 
         case INTPTR_TYPE:
             lua_pop(L, 1);
-            dasm_put(Dst, 1000);
+            dasm_put(Dst, 706);
             break;
 
         case FLOAT_TYPE:
         case DOUBLE_TYPE:
             lua_pop(L, 1);
-            dasm_put(Dst, 1047);
+            dasm_put(Dst, 753);
             if (mt->type == FLOAT_TYPE) {
             } else {
             }
-            dasm_put(Dst, 1067);
+            dasm_put(Dst, 773);
             break;
 
         case COMPLEX_FLOAT_TYPE:
@@ -762,7 +725,7 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
 #endif
             /* on 64 bit complex floats are two floats packed into a double,
              * on 32 bit returned complex floats use eax and edx */
-            dasm_put(Dst, 1095);
+            dasm_put(Dst, 801);
             break;
 
         case COMPLEX_DOUBLE_TYPE:
@@ -775,9 +738,9 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
              * the returned arg is stored which is popped by the called
              * function */
 #if defined _WIN64 || defined __amd64__
-            dasm_put(Dst, 1150);
+            dasm_put(Dst, 856);
 #else
-            dasm_put(Dst, 1215, hidden_arg_off);
+            dasm_put(Dst, 921, hidden_arg_off);
 #endif
             break;
 
@@ -786,7 +749,7 @@ cfunction compile_callback(lua_State* L, int fidx, int ct_usr, const struct ctyp
         }
     }
 
-    dasm_put(Dst, 1265, x86_return_size(L, ct_usr, ct));
+    dasm_put(Dst, 971, x86_return_size(L, ct_usr, ct));
 
     lua_pop(L, 1); /* upval table - already in registry */
     assert(lua_gettop(L) == top);
@@ -828,15 +791,18 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
         luaL_error(L, "vararg is only allowed with the c calling convention");
     }
 
-    dasm_put(Dst, 1276, 8, nargs);
-
+    dasm_put(Dst, 982, 8, nargs);
     if (!ct->has_var_arg) {
-        dasm_put(Dst, 1306);
+        dasm_put(Dst, 1008, (ptrdiff_t)("too few arguments"), (ptrdiff_t)("too many arguments"));
+    } else {
+        dasm_put(Dst, 1051, (ptrdiff_t)("too few arguments"));
     }
+
+    dasm_put(Dst, 1072);
 
     /* no need to zero extend eax returned by lua_gettop to rax as x86-64
      * preguarentees that the upper 32 bits will be zero */
-    dasm_put(Dst, 1311, 32 + REGISTER_STACK_SPACE(ct));
+    dasm_put(Dst, 1075, 32 + REGISTER_STACK_SPACE(ct));
 
 #if !defined _WIN64 && !defined __amd64__
     /* Returned complex doubles require a hidden first parameter where the
@@ -847,7 +813,7 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
         /* we can allocate more space for arguments as long as no add_*
          * function has been called yet, mbr_ct will be added as an upvalue in
          * the return processing later */
-        dasm_put(Dst, 1321, mbr_ct);
+        dasm_put(Dst, 1085, mbr_ct);
         add_pointer(Dst, ct, &reg);
     }
     lua_pop(L, 1);
@@ -860,80 +826,80 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
         if (mbr_ct->pointers || mbr_ct->is_reference) {
             lua_getuservalue(L, -1);
             num_upvals += 2;
-            dasm_put(Dst, 1346, mbr_ct, lua_upvalueindex(num_upvals), i);
+            dasm_put(Dst, 1110, mbr_ct, lua_upvalueindex(num_upvals), i);
             add_pointer(Dst, ct, &reg);
         } else {
             switch (mbr_ct->type) {
             case FUNCTION_PTR_TYPE:
                 lua_getuservalue(L, -1);
                 num_upvals += 2;
-                dasm_put(Dst, 1369, mbr_ct, lua_upvalueindex(num_upvals), i);
+                dasm_put(Dst, 1133, mbr_ct, lua_upvalueindex(num_upvals), i);
                 add_pointer(Dst, ct, &reg);
                 break;
 
             case ENUM_TYPE:
                 lua_getuservalue(L, -1);
                 num_upvals += 2;
-                dasm_put(Dst, 1392, mbr_ct, lua_upvalueindex(num_upvals), i);
+                dasm_put(Dst, 1156, mbr_ct, lua_upvalueindex(num_upvals), i);
                 add_int(Dst, ct, &reg, 0);
                 break;
 
             case INT8_TYPE:
-                dasm_put(Dst, 1415, i);
+                dasm_put(Dst, 1179, i);
                 if (mbr_ct->is_unsigned) {
-                    dasm_put(Dst, 1428);
+                    dasm_put(Dst, 1192);
                 } else {
-                    dasm_put(Dst, 1432);
+                    dasm_put(Dst, 1196);
                 }
                 add_int(Dst, ct, &reg, 0);
                 lua_pop(L, 1);
                 break;
 
             case INT16_TYPE:
-                dasm_put(Dst, 1415, i);
+                dasm_put(Dst, 1179, i);
                 if (mbr_ct->is_unsigned) {
-                    dasm_put(Dst, 1436);
+                    dasm_put(Dst, 1200);
                 } else {
-                    dasm_put(Dst, 1440);
+                    dasm_put(Dst, 1204);
                 }
                 add_int(Dst, ct, &reg, 0);
                 lua_pop(L, 1);
                 break;
 
             case BOOL_TYPE:
-                dasm_put(Dst, 1444, i);
+                dasm_put(Dst, 1208, i);
                 add_int(Dst, ct, &reg, 0);
                 lua_pop(L, 1);
                 break;
 
             case INT32_TYPE:
                 if (mbr_ct->is_unsigned) {
-                    dasm_put(Dst, 1467, i);
+                    dasm_put(Dst, 1231, i);
                 } else {
-                    dasm_put(Dst, 1415, i);
+                    dasm_put(Dst, 1179, i);
                 }
                 add_int(Dst, ct, &reg, 0);
                 lua_pop(L, 1);
                 break;
 
             case INTPTR_TYPE:
-                dasm_put(Dst, 1480, i);
+                dasm_put(Dst, 1244, i);
                 add_pointer(Dst, ct, &reg);
                 lua_pop(L, 1);
                 break;
 
             case INT64_TYPE:
                 if (mbr_ct->is_unsigned) {
-                    dasm_put(Dst, 1493, i);
+                    dasm_put(Dst, 1257, i);
                 } else {
-                    dasm_put(Dst, 1506, i);
+                    dasm_put(Dst, 1270, i);
                 }
                 add_int(Dst, ct, &reg, 1);
                 lua_pop(L, 1);
                 break;
 
             case DOUBLE_TYPE:
-                dasm_put(Dst, 1519, i);
+                dasm_put(Dst, 1283, i);
                 add_float(Dst, ct, &reg, 1);
                 lua_pop(L, 1);
                 break;
@@ -944,33 +910,33 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
                  * the returned arg is stored (this is popped by the called
                  * function) */
 #if defined _WIN64 || defined __amd64__
-                dasm_put(Dst, 1532, i);
+                dasm_put(Dst, 1296, i);
                 add_float(Dst, ct, &reg, 1);
-                dasm_put(Dst, 1545);
+                dasm_put(Dst, 1309);
                 add_float(Dst, ct, &reg, 1);
 #else
-                dasm_put(Dst, 1551, reg.off, i);
+                dasm_put(Dst, 1315, reg.off, i);
                 reg.off += 16;
 #endif
                 lua_pop(L, 1);
                 break;
 
             case FLOAT_TYPE:
-                dasm_put(Dst, 1519, i);
+                dasm_put(Dst, 1283, i);
                 add_float(Dst, ct, &reg, 0);
                 lua_pop(L, 1);
                 break;
 
             case COMPLEX_FLOAT_TYPE:
 #if defined _WIN64 || defined __amd64__
-                dasm_put(Dst, 1577, i);
+                dasm_put(Dst, 1341, i);
                 /* complex floats are two floats packed into a double */
                 add_float(Dst, ct, &reg, 1);
 #else
                 /* returned complex floats use eax and edx */
-                dasm_put(Dst, 1590, i);
+                dasm_put(Dst, 1354, i);
                 add_float(Dst, ct, &reg, 0);
-                dasm_put(Dst, 1609);
+                dasm_put(Dst, 1373);
                 add_float(Dst, ct, &reg, 0);
 #endif
                 lua_pop(L, 1);
@@ -1004,14 +970,14 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
         reg.floats = MAX_FLOAT_REGISTERS(ct);
         reg.ints = MAX_INT_REGISTERS(ct);
 #else
-        dasm_put(Dst, 1616, reg.off, nargs+1);
+        dasm_put(Dst, 1380, reg.off, nargs+1);
 #endif
     }
 
-    dasm_put(Dst, 1642, perr);
+    dasm_put(Dst, 1406, perr);
 
     /* remove the stack space to call local functions */
-    dasm_put(Dst, 1654);
+    dasm_put(Dst, 1418);
 
 #ifdef _WIN64
     switch (reg.regs) {
@@ -1071,14 +1037,14 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
     if (ct->calling_convention == FAST_CALL) {
         switch (reg.ints) {
         case 2:
-            dasm_put(Dst, 1658, 4);
+            dasm_put(Dst, 1422, 4);
         case 1:
-            dasm_put(Dst, 1664);
+            dasm_put(Dst, 1428);
         case 0:
             break;
         }
 
-        dasm_put(Dst, 1668, REGISTER_STACK_SPACE(ct));
+        dasm_put(Dst, 1432, REGISTER_STACK_SPACE(ct));
     }
 #endif
 
@@ -1090,7 +1056,7 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
     }
 #endif
 
-    dasm_put(Dst, 1672);
+    dasm_put(Dst, 1436);
 
     /* note on windows X86 the stack may be only aligned to 4 (stdcall will
      * have popped a multiple of 4 bytes), but we don't need 16 byte alignment on
@@ -1103,90 +1069,90 @@ void compile_function(lua_State* L, cfunction func, int ct_usr, const struct cty
     if (mbr_ct->pointers || mbr_ct->is_reference || mbr_ct->type == INTPTR_TYPE) {
         lua_getuservalue(L, -1);
         num_upvals += 2;
-        dasm_put(Dst, 1681, perr, mbr_ct, lua_upvalueindex(num_upvals));
+        dasm_put(Dst, 1445, perr, mbr_ct, lua_upvalueindex(num_upvals));
 
     } else {
         switch (mbr_ct->type) {
         case FUNCTION_PTR_TYPE:
             lua_getuservalue(L, -1);
             num_upvals += 2;
-            dasm_put(Dst, 1681, perr, mbr_ct, lua_upvalueindex(num_upvals));
+            dasm_put(Dst, 1445, perr, mbr_ct, lua_upvalueindex(num_upvals));
             break;
 
         case INT64_TYPE:
 #if LUA_VERSION_NUM == 503
             lua_pop(L, 1);
             if (mbr_ct->is_unsigned) {
-                dasm_put(Dst, 1721);
+                dasm_put(Dst, 1499, perr);
             } else {
-                dasm_put(Dst, 1726);
+                dasm_put(Dst, 1499, perr);
             }
 #else
             num_upvals++;
-            dasm_put(Dst, 1731, perr, mbr_ct);
+            dasm_put(Dst, 1545, perr, mbr_ct);
 #endif
             break;
 
         case COMPLEX_FLOAT_TYPE:
             lua_getuservalue(L, -1);
             num_upvals += 2;
-            dasm_put(Dst, 1785, perr, mbr_ct, lua_upvalueindex(num_upvals));
+            dasm_put(Dst, 1613, perr, mbr_ct, lua_upvalueindex(num_upvals));
             break;
 
         case COMPLEX_DOUBLE_TYPE:
             lua_getuservalue(L, -1);
             num_upvals += 2;
-            dasm_put(Dst, 1836, perr);
+            dasm_put(Dst, 1678, perr);
             break;
 
         case VOID_TYPE:
             lua_pop(L, 1);
-            dasm_put(Dst, 1853);
+            dasm_put(Dst, 1709, perr);
             break;
 
         case BOOL_TYPE:
             lua_pop(L, 1);
-            dasm_put(Dst, 1858);
+            dasm_put(Dst, 1736, perr);
             break;
 
         case INT8_TYPE:
             lua_pop(L, 1);
             if (mbr_ct->is_unsigned) {
-                dasm_put(Dst, 1428);
+                dasm_put(Dst, 1192);
             } else {
-                dasm_put(Dst, 1432);
+                dasm_put(Dst, 1196);
             }
-            dasm_put(Dst, 1863);
+            dasm_put(Dst, 1785, perr);
             break;
 
         case INT16_TYPE:
             lua_pop(L, 1);
             if (mbr_ct->is_unsigned) {
-                dasm_put(Dst, 1436);
+                dasm_put(Dst, 1200);
             } else {
-                dasm_put(Dst, 1440);
+                dasm_put(Dst, 1204);
             }
-            dasm_put(Dst, 1863);
+            dasm_put(Dst, 1785, perr);
             break;
 
         case INT32_TYPE:
         case ENUM_TYPE:
             lua_pop(L, 1);
             if (mbr_ct->is_unsigned) {
-                dasm_put(Dst, 1868);
+                dasm_put(Dst, 1831, perr);
             } else {
-                dasm_put(Dst, 1863);
+                dasm_put(Dst, 1785, perr);
             }
             break;
 
         case FLOAT_TYPE:
             lua_pop(L, 1);
-            dasm_put(Dst, 1873);
+            dasm_put(Dst, 1877, perr);
             break;
 
         case DOUBLE_TYPE:
             lua_pop(L, 1);
-            dasm_put(Dst, 1873);
+            dasm_put(Dst, 1877, perr);
             break;
 
         default:


### PR DESCRIPTION
If the code pages for the shared global functions happen to be allocated more than 2GB away
from other generated code, malformed jumps will be emitted, and crashes ensue.
This fixes the issue by turning the global functions into macros. They were all quite small,
so this should have minimal impact on code size.
